### PR TITLE
Debug Fill on Drag

### DIFF
--- a/app/grid/page.tsx
+++ b/app/grid/page.tsx
@@ -1,26 +1,7 @@
-"use client";
-import { useState } from "react";
-
-import Grid from "@/components/Grid";
-
-import PatternForm from "@/components/PatternForm";
-import { Pattern } from "@/types/pattern";
+import Pattern from "@/components/Pattern";
 
 function Page() {
-  const [pattern, setPattern] = useState<Pattern>({
-    title: "",
-    gridWidth: 12,
-    gridHeight: 12,
-  });
-
-  return (
-    <>
-      <h1>Create a new pattern</h1>
-      <PatternForm pattern={pattern} setPattern={setPattern} />
-
-      <Grid height={pattern.gridHeight} width={pattern.gridWidth} />
-    </>
-  );
+  return <Pattern />;
 }
 
 export default Page;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,8 @@
-import "@/styles/globals.css";
-
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 
 import Grid from "@/components/Grid";
+import "@/styles/globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
 

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import GridPixel from "@/components/Pixel";
+import Button from "./Button";
+
 // TODO
 // allow user to create their own grid with custom size
 // allow user to name the pattern and save to their account
@@ -9,9 +11,8 @@ import GridPixel from "@/components/Pixel";
 // add a paint dropper tool
 // allow selecting color with hex code/manually
 
-// allow dragging to fill multiple pixels on the grid
+// split grid into rows and cols
 function Grid({ height, width }: { height?: number; width?: number }) {
-  // TODO: split grid into rows and cols
   const [mouseIsDown, setMouseDownState] = useState(false);
 
   const pixels =

--- a/components/Pattern.tsx
+++ b/components/Pattern.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useState } from "react";
+
+import Grid from "@/components/Grid";
+
+import PatternForm from "@/components/PatternForm";
+import { Pattern } from "@/types/pattern";
+
+function Pattern() {
+  const [pattern, setPattern] = useState<Pattern>({
+    title: "",
+    gridWidth: 12,
+    gridHeight: 12,
+  });
+
+  return (
+    <>
+      <h1>Create a new pattern</h1>
+      <PatternForm pattern={pattern} setPattern={setPattern} />
+      <Grid height={pattern.gridHeight} width={pattern.gridWidth} />
+    </>
+  );
+}
+
+export default Pattern;

--- a/components/PatternForm.tsx
+++ b/components/PatternForm.tsx
@@ -1,5 +1,7 @@
+import { SetStateAction } from "react";
 import { Pattern } from "@/types/pattern";
-import { SetStateAction, useEffect } from "react";
+import { usePixelIsFilled } from "@/hooks/usePixelFillState";
+
 import Button from "@/components/Button";
 
 function PatternForm({
@@ -9,6 +11,13 @@ function PatternForm({
   pattern: Pattern;
   setPattern: React.Dispatch<SetStateAction<Pattern>>;
 }) {
+  const {
+    pixelIsFilled,
+    setPixelIsFilled,
+    setPixelFillColor,
+    resetPixelFillColor,
+  } = usePixelIsFilled();
+
   function handleSubmit(e: React.MouseEvent) {
     e.preventDefault();
     console.log("saving pattern to your account");
@@ -33,15 +42,10 @@ function PatternForm({
     let pixels = document.querySelectorAll(".grid-pixel");
     pixels &&
       pixels.forEach((p) => {
-        p.classList.remove("bg-green-700");
-        p.classList.remove("text-green-700");
-        p.classList.add("text-white");
+        resetPixelFillColor(p, "bg-green-700");
+        setPixelIsFilled(false);
       });
   }
-
-  //   useEffect(() => {
-  //     pattern && console.log(pattern);
-  //   }, [pattern, setPattern]);
 
   return (
     <form>

--- a/components/PatternForm.tsx
+++ b/components/PatternForm.tsx
@@ -61,12 +61,10 @@ function PatternForm({
 
         <Button handleClick={handleUpdateGrid} buttonText="Update Grid" />
       </div>
-
       <Button
         handleClick={handleSubmit}
         buttonText="Save Pattern to your Account"
       />
-
       <Button handleClick={handleResetGrid} buttonText="Reset Grid" />
     </form>
   );

--- a/components/Pixel.tsx
+++ b/components/Pixel.tsx
@@ -1,37 +1,28 @@
-import { useState } from "react";
+import { usePixelIsFilled } from "@/hooks/usePixelFillState";
 
 // TODO: Look into using canvas instead of React/JS + event listeners
 // https://stackoverflow.com/questions/28284754/dragging-shapes-using-mouse-after-creating-them-with-html5-canvas
 
 // TODO remove hard-coded pixel fill color (set up color vars - tailwind config)
 function GridPixel({ mouseIsDown }: { mouseIsDown: boolean }) {
-  const [pixelIsFilled, setPixelFillState] = useState(false);
-
-  function setPixelFillColor(pixel: HTMLInputElement, color: string) {
-    pixel.classList.add(color);
-  }
-
-  function resetPixelFillColor(pixel: HTMLInputElement, color: string) {
-    pixel.classList.remove("bg-green-700");
-  }
+  const {
+    pixelIsFilled,
+    setPixelIsFilled,
+    setPixelFillColor,
+    resetPixelFillColor,
+  } = usePixelIsFilled();
 
   function handleClick(e: React.MouseEvent) {
     const target = e.target as HTMLInputElement;
 
     if (target) {
-      setPixelFillState(!pixelIsFilled);
-
       if (!pixelIsFilled) {
+        setPixelIsFilled(true);
         setPixelFillColor(target, "bg-green-700");
       } else if (pixelIsFilled) {
+        setPixelIsFilled(false);
         resetPixelFillColor(target, "bg-green-700");
       }
-
-      target.addEventListener("mouseenter", function () {
-        if (mouseIsDown) {
-          setPixelFillColor(target, "bg-green-700");
-        }
-      });
     }
   }
 

--- a/components/Pixel.tsx
+++ b/components/Pixel.tsx
@@ -30,11 +30,10 @@ function GridPixel({ mouseIsDown }: { mouseIsDown: boolean }) {
     const target = e.target as HTMLInputElement;
 
     if (target) {
-      target.addEventListener("mouseenter", function () {
-        if (mouseIsDown) {
-          setPixelFillColor(target, "bg-green-700");
-        }
-      });
+      if (mouseIsDown) {
+        setPixelIsFilled(true);
+        setPixelFillColor(target, "bg-green-700");
+      }
     }
   }
 
@@ -42,7 +41,7 @@ function GridPixel({ mouseIsDown }: { mouseIsDown: boolean }) {
     <div
       onMouseDown={handleClick}
       onMouseEnter={handleClickandDrag}
-      className="grid-pixel text-white border-solid border-y border-x w-4 h-4 p-4"
+      className="grid-pixel border-solid border-y border-x w-4 h-4 p-4"
     ></div>
   );
 }

--- a/hooks/usePixelFillState.tsx
+++ b/hooks/usePixelFillState.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+
+export function usePixelIsFilled() {
+  const [pixelIsFilled, setPixelIsFilled] = useState(false);
+
+  function setPixelFillColor(pixel: Element, color: string) {
+    pixel.classList.add(color);
+  }
+
+  function resetPixelFillColor(pixel: Element, color: string) {
+    pixel.classList.remove("bg-green-700");
+  }
+
+  return {
+    pixelIsFilled,
+    setPixelIsFilled,
+    setPixelFillColor,
+    resetPixelFillColor,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
       "@/assets": ["./assets"],
       "@/lib": ["./lib"],
       "@/styles": ["./styles"],
-      "@/components": ["./components"]
+      "@/components": ["./components"],
+      "@/hooks": ["./hooks"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
| ✔️ | Bug Fix |
| | New Feature  |
| ✔️ | Refactor  |
| | Update Deps  |
| | Documentation  |

### Description
---

**🐛 Bug Fixes**
- _Removed on mouse enter event listeners that were causing pixels to continue being filled even after resetting the grid._
- _Removed extraneous 'text color' from the GridPixel component's class list. This is no longer needed since pixels don't have any text content._

**⚙️ Refactor**
- _Extracted Pattern to its own component and imported/rendered in `grid/page.tsx`_
- _Added hooks folder and updated the `.tsconfig` to add a new alias for it._
- _Extracted pixel fill state and set/reset pixel color logic to a custom hook so it could be imported in multiple places for use as needed. This allowed not only setting pixel fill state and color in the GridPixel component, but also in places like the resetGrid handler which lives in the Pattern Form component._


### To-Dos
---
- [ ] _First attempt to click and drag still buggy, the very first pixel clicked gets filled, but mouse button has to be released and clicked a second time to fill multiple pixels on drag_
