### PR TITLE
Custom Grid Size

### DIFF
--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import GridPixel from "@/components/Pixel";
-import Button from "./Button";
 
 // TODO
 // allow user to create their own grid with custom size
@@ -15,8 +14,15 @@ import Button from "./Button";
 function Grid({ height, width }: { height?: number; width?: number }) {
   const [mouseIsDown, setMouseDownState] = useState(false);
 
-  const pixels =
-    height && width && new Array(height * width).fill(height * width);
+  var pixels: JSX.Element[][] = new Array(height).fill(
+    new Array(width).fill(<GridPixel mouseIsDown={mouseIsDown} />)
+  );
+
+  pixels?.forEach((p) => {
+    for (var i = 0; i < p.length; i++) {
+      p[i] = <GridPixel mouseIsDown={mouseIsDown} key={i} />;
+    }
+  });
 
   function handleClick(e: React.MouseEvent) {
     const target = e.target as HTMLInputElement;

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -32,11 +32,11 @@ function Grid({ height, width }: { height?: number; width?: number }) {
   return (
     <div onClick={handleClick}>
       <div className="flex justify-center">
-        <div className=" border-solid border-2 grid grid-cols-12">
-          {pixels &&
-            pixels.map((p, i) => (
-              <GridPixel mouseIsDown={mouseIsDown} key={i} />
-            ))}
+        <div
+          style={{ gridTemplateColumns: `repeat(${width}, minmax(0, 1fr))` }}
+          className=" border-solid border-2 grid"
+        >
+          {pixels && pixels}
         </div>
       </div>
     </div>

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -1,16 +1,7 @@
 import { useState } from "react";
 import GridPixel from "@/components/Pixel";
 
-// TODO
-// allow user to create their own grid with custom size
 // allow user to name the pattern and save to their account
-
-// center the grid and add styles
-
-// add a paint dropper tool
-// allow selecting color with hex code/manually
-
-// split grid into rows and cols
 function Grid({ height, width }: { height?: number; width?: number }) {
   const [mouseIsDown, setMouseDownState] = useState(false);
 

--- a/components/Pattern.tsx
+++ b/components/Pattern.tsx
@@ -2,16 +2,16 @@
 import { useState } from "react";
 import ContextProvider from "@/context/GridContext";
 
+import PatternForm from "@/components/PatternForm";
 import Grid from "@/components/Grid";
 
-import PatternForm from "@/components/PatternForm";
 import { Pattern } from "@/types/pattern";
 
 function Pattern() {
   const [pattern, setPattern] = useState<Pattern>({
     title: "",
-    gridWidth: 12,
-    gridHeight: 12,
+    gridHeight: 25,
+    gridWidth: 25,
   });
 
   return (

--- a/components/PatternForm.tsx
+++ b/components/PatternForm.tsx
@@ -12,8 +12,7 @@ function PatternForm({
   setPattern: React.Dispatch<SetStateAction<Pattern>>;
 }) {
   const { setPixelFillColor } = useGridContext();
-  const { pixelIsFilled, setPixelIsFilled, removePixelFill } =
-    usePixelIsFilled();
+  const { setPixelIsFilled, removePixelFill } = usePixelIsFilled();
 
   function handleSubmit(e: React.MouseEvent) {
     e.preventDefault();

--- a/components/PatternForm.tsx
+++ b/components/PatternForm.tsx
@@ -19,33 +19,47 @@ function PatternForm({
     console.log("saving pattern to your account");
   }
 
+  function setPatternState(
+    p: Pattern = {
+      title: undefined,
+      gridWidth: undefined,
+      gridHeight: undefined,
+    }
+  ) {
+    const heightInput = document.getElementById("height") as HTMLInputElement;
+    const widthInput = document.getElementById("width") as HTMLInputElement;
+    const titleInput = document.getElementById("title") as HTMLInputElement;
+
+    // Get the new pattern state values from user or function args
+    const updatedPatternState = {
+      title: p.title ? p.title : titleInput.value,
+      gridWidth: p.gridWidth ? p.gridWidth : widthInput.valueAsNumber,
+      gridHeight: p.gridHeight ? p.gridHeight : heightInput.valueAsNumber,
+    };
+
+    // Don't update values unless they were explicitly modified
+    Object.entries(updatedPatternState).forEach((entry) => {
+      if (entry[1]) {
+        setPattern((prevState) => ({
+          ...prevState,
+          [entry[0]]: entry[1],
+        }));
+      }
+    });
+  }
+
   function handleUpdateGrid(e: React.MouseEvent) {
     e.preventDefault();
 
-    const height = document.getElementById("height") as HTMLInputElement;
-    const width = document.getElementById("width") as HTMLInputElement;
-    const title = document.getElementById("title") as HTMLInputElement;
     const updatedPixelFillColor = document.getElementById(
       "pixelFillColor"
     ) as HTMLInputElement;
 
-    const updatedPatternState = {
-      title: title.value,
-      gridWidth: width.valueAsNumber,
-      gridHeight: height.valueAsNumber,
-    };
-
     try {
-      setPixelFillColor(updatedPixelFillColor.value);
-
-      Object.entries(updatedPatternState).forEach((entry) => {
-        if (entry[1]) {
-          setPattern((prevState) => ({
-            ...prevState,
-            [entry[0]]: entry[1],
-          }));
-        }
-      });
+      updatedPixelFillColor.value && updatedPixelFillColor.value !== ""
+        ? setPixelFillColor(updatedPixelFillColor.value)
+        : null;
+      setPatternState();
     } catch (e) {
       console.log("Error updating the grid", e);
       throw new Error();
@@ -53,12 +67,20 @@ function PatternForm({
   }
 
   function handleResetGrid(e: React.MouseEvent) {
-    e.preventDefault();
-    const target = e.target as HTMLButtonElement;
+    handleSetGridtoDefault(e);
+    handleRemoveGridFill();
+  }
 
+  function handleSetGridtoDefault(e: React.MouseEvent) {
+    e.preventDefault();
+    setPatternState({ title: "", gridWidth: 25, gridHeight: 25 });
+  }
+
+  function handleRemoveGridFill() {
     let pixels = document.querySelectorAll(
       ".grid-pixel"
     ) as NodeListOf<HTMLDivElement>;
+
     pixels &&
       pixels.forEach((p) => {
         removePixelFill(p);
@@ -113,6 +135,11 @@ function PatternForm({
       <div className="m-4 ml-0">
         <Button handleClick={handleUpdateGrid} buttonText="Save Changes" />
         <Button handleClick={handleResetGrid} buttonText="Reset Grid" />
+        <Button
+          handleClick={handleRemoveGridFill}
+          buttonText="Remove Pixel Fill"
+        />
+        <Button handleClick={handleSetGridtoDefault} buttonText="Reset Size" />
         <Button handleClick={handleSubmit} buttonText="Save Pattern" />
       </div>
     </form>

--- a/components/PatternForm.tsx
+++ b/components/PatternForm.tsx
@@ -1,9 +1,8 @@
 import { SetStateAction } from "react";
-import { Pattern } from "@/types/pattern";
-import { usePixelIsFilled } from "@/hooks/usePixelFillState";
-
-import Button from "@/components/Button";
 import { useGridContext } from "@/context/GridContext";
+import { usePixelIsFilled } from "@/hooks/usePixelFillState";
+import Button from "@/components/Button";
+import { Pattern } from "@/types/pattern";
 
 function PatternForm({
   pattern,

--- a/components/Pixel.tsx
+++ b/components/Pixel.tsx
@@ -1,14 +1,9 @@
 "use client";
-import { useGridContext } from "@/context/GridContext";
 import { usePixelIsFilled } from "@/hooks/usePixelFillState";
-
-// TODO: Look into using canvas instead of React/JS + event listeners
-// https://stackoverflow.com/questions/28284754/dragging-shapes-using-mouse-after-creating-them-with-html5-canvas
 
 function GridPixel({ mouseIsDown }: { mouseIsDown: boolean }) {
   const { pixelIsFilled, setPixelIsFilled, fillGridPixel, removePixelFill } =
     usePixelIsFilled();
-  const { pixelFillColor } = useGridContext();
 
   function handleClick(e: React.MouseEvent) {
     const target = e.target as HTMLDivElement;

--- a/components/Pixel.tsx
+++ b/components/Pixel.tsx
@@ -39,7 +39,7 @@ function GridPixel({ mouseIsDown }: { mouseIsDown: boolean }) {
     <div
       onMouseDown={handleClick}
       onMouseEnter={handleClickandDrag}
-      className="grid-pixel border-solid border-y border-x w-4 h-4 p-3"
+      className="grid-pixel border-solid border-y border-x w-4 h-4 p-2"
     ></div>
   );
 }

--- a/context/GridContext.tsx
+++ b/context/GridContext.tsx
@@ -8,9 +8,11 @@ export default function ContextProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [pixelFillColor, setPixelFillColor] = useState("#0000FF");
+  const defaultFillColor = "#0000FF";
+  const [pixelFillColor, setPixelFillColor] = useState(defaultFillColor);
 
   const ctx: GridContextType = {
+    defaultFillColor,
     pixelFillColor,
     setPixelFillColor,
   };

--- a/types/context.ts
+++ b/types/context.ts
@@ -1,6 +1,7 @@
 import { SetStateAction } from "react";
 
 export type GridContextType = {
+  defaultFillColor: string;
   pixelFillColor: string;
   setPixelFillColor: React.Dispatch<SetStateAction<string>>;
 };

--- a/types/pattern.ts
+++ b/types/pattern.ts
@@ -1,5 +1,5 @@
 export type Pattern = {
-  title: string;
-  gridWidth: number;
-  gridHeight: number;
+  title: string | undefined;
+  gridWidth: number | undefined;
+  gridHeight: number | undefined;
 };


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
|✔️| Bug Fix |
|| New Feature  |
|✔️| Refactor  |
|| Update Deps  |
|| Documentation  |

### Description
---
**⚙️ Refactor Changes**
- Refactored the setState logic for Patterns out to its own function so that it can be called in multiple places without having to duplicate the document querySelector calls. Both `handleUpdateGrid()` and `handleSetGridtoDefault()` call `setPattern()`.

    > setPattern() checks for a `pattern` argument and tries to use that to save the new pattern to state. If there is no object passed to the function at call time it will try to fetch values from the PatternForm component instead. It will update only the pattern state properties that were modified, leaving the others untouched.

- Added a couple new buttons to allow granular control over the Grid.
A user can now:
  > Save Changes to the pattern (calls handleUpdateGrid)
  > Reset the entire grid (calls both handleRemoveGridFill and handleSetGridtoDefault)
  > Reset just the grid size to default (calls handleSetGridtoDefault)
  > Reset the pixel fill states on the current grid (handleRemoveGridFill)

- Added a 'default' pixel fill color to fall back on when the user has not set one explicitly.
- Changed the default Grid size to 25x25 pixels and the default pixel size to 2px (instead of 3).

**🐛 Debug Changes**
- Updated the Pattern type to allow undefined pattern values.
- Update the Grid to render pixels dynamically, allowing the user to set their own custom grid size using the Pattern Form.
    > Modified the way the Grid component renders each pixel. Was previously creating a new Array and filling it with a series of numbers corresponding to the pattern height multiplied by its width. The new `pixels` variable stores an Array with a number of nested arrays equal to the pattern height. Each 'row' is then filled with a number of Pixel components equal to the pattern width.