### PR TITLE
Grid Max Width Error-Handling and Debug removePixelFill Resets Grid to Default Size

### DIFF
--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -31,10 +31,10 @@ function Grid({ height, width }: { height?: number; width?: number }) {
 
   return (
     <div onClick={handleClick}>
-      <div className="flex justify-center">
+      <div className="flex justify-center" id="grid">
         <div
           style={{ gridTemplateColumns: `repeat(${width}, minmax(0, 1fr))` }}
-          className=" border-solid border-2 grid"
+          className="border-solid border-2 grid"
         >
           {pixels && pixels}
         </div>

--- a/components/PatternForm.tsx
+++ b/components/PatternForm.tsx
@@ -11,7 +11,7 @@ function PatternForm({
   pattern: Pattern;
   setPattern: React.Dispatch<SetStateAction<Pattern>>;
 }) {
-  const { setPixelFillColor } = useGridContext();
+  const { setPixelFillColor, maxGridWidth } = useGridContext();
   const { setPixelIsFilled, removePixelFill } = usePixelIsFilled();
 
   function handleSubmit(e: React.MouseEvent) {
@@ -33,9 +33,22 @@ function PatternForm({
     // Get the new pattern state values from user or function args
     const updatedPatternState = {
       title: p.title ? p.title : titleInput.value,
-      gridWidth: p.gridWidth ? p.gridWidth : widthInput.valueAsNumber,
+      gridWidth: p.gridWidth
+        ? p.gridWidth
+        : widthInput.valueAsNumber <= maxGridWidth
+        ? widthInput.valueAsNumber
+        : null,
       gridHeight: p.gridHeight ? p.gridHeight : heightInput.valueAsNumber,
     };
+
+    if (
+      (p.gridWidth && p.gridWidth > maxGridWidth) ||
+      widthInput.valueAsNumber > maxGridWidth
+    ) {
+      return {
+        msg: "Sorry, your pattern is too wide! Try setting a smaller width.",
+      };
+    }
 
     // Don't update values unless they were explicitly modified
     Object.entries(updatedPatternState).forEach((entry) => {
@@ -59,7 +72,8 @@ function PatternForm({
       updatedPixelFillColor.value && updatedPixelFillColor.value !== ""
         ? setPixelFillColor(updatedPixelFillColor.value)
         : null;
-      setPatternState();
+      const result = setPatternState();
+      if (result) alert(result.msg);
     } catch (e) {
       console.log("Error updating the grid", e);
       throw new Error();
@@ -68,15 +82,21 @@ function PatternForm({
 
   function handleResetGrid(e: React.MouseEvent) {
     handleSetGridtoDefault(e);
-    handleRemoveGridFill();
+    handleRemoveGridFill(e);
   }
 
   function handleSetGridtoDefault(e: React.MouseEvent) {
     e.preventDefault();
-    setPatternState({ title: "", gridWidth: 25, gridHeight: 25 });
+    const result = setPatternState({
+      title: "",
+      gridWidth: 25,
+      gridHeight: 25,
+    });
+    if (result) alert(result.msg);
   }
 
-  function handleRemoveGridFill() {
+  function handleRemoveGridFill(e: React.MouseEvent) {
+    e.preventDefault();
     let pixels = document.querySelectorAll(
       ".grid-pixel"
     ) as NodeListOf<HTMLDivElement>;

--- a/context/GridContext.tsx
+++ b/context/GridContext.tsx
@@ -9,10 +9,12 @@ export default function ContextProvider({
   children: React.ReactNode;
 }) {
   const defaultFillColor = "#0000FF";
+  const maxGridWidth = 80;
   const [pixelFillColor, setPixelFillColor] = useState(defaultFillColor);
 
   const ctx: GridContextType = {
     defaultFillColor,
+    maxGridWidth,
     pixelFillColor,
     setPixelFillColor,
   };

--- a/types/context.ts
+++ b/types/context.ts
@@ -2,6 +2,7 @@ import { SetStateAction } from "react";
 
 export type GridContextType = {
   defaultFillColor: string;
+  maxGridWidth: number;
   pixelFillColor: string;
   setPixelFillColor: React.Dispatch<SetStateAction<string>>;
 };


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
|✔️| Bug Fix |
| | New Feature  |
|✔️| Refactor  |
| | Update Deps  |
| | Documentation  |

### Description
---
**Refactor Changes**
- Added `maxGridSize` value to GridContext
- Added some logic to prevent the user from setting a width higher than 80

**🐛 Debug Changes**
- Fixed Reset Pixel Fill State refreshes the page (also resetting the grid size).

### To-Dos
---
- [ ] Refactor max-width logic to prevent grid pixels from overlapping/collapsing when the grid is too large for the viewport.
- [ ] Grid max-width logic should compare the grid component width to the actual viewport width, to allow different max widths for different browser/device sizes (currently hard-coded to check for width < 80).
