### PR TITLE
Delete update grid

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -24,7 +24,7 @@ const Main = async () => {
 
             <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-4 lg:text-left">
                 <a
-                    href={userId ? "/pattern" : "/new-user"}
+                    href="/pattern"
                     className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
                     rel="noopener noreferrer"
                 >

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,9 +23,10 @@ export default function RootLayout({
     return (
         <ClerkProvider {...pageProps}>
             <html lang="en">
-                <body className={`${inter.className} p-10`}>
+                <body className={`${inter.className} pb-10`}>
                     <div className="flex h-screen flex-col">
                         <Header />
+                        <hr />
                         <main>{children}</main>
                         <Footer />
                     </div>

--- a/app/pattern/page.tsx
+++ b/app/pattern/page.tsx
@@ -3,15 +3,18 @@ import PatternForm from "@/components/PatternForm"
 import Grid from "@/components/Grid"
 import PatternList from "@/components/PatternList"
 import PatternDetail from "@/components/PatternDetail"
+import { auth } from "@clerk/nextjs"
 
 export const dynamic = "force-dynamic"
-function Page() {
+async function Page() {
+    const { userId } = await auth()
+
     return (
         <ContextProvider>
-            <PatternForm />
-            <PatternDetail />
+            <PatternForm authorized={userId ? true : false} />
+            <PatternDetail authorized={userId ? true : false} />
             <Grid />
-            <PatternList />
+            {userId && <PatternList />}
         </ContextProvider>
     )
 }

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -19,7 +19,7 @@ function Button({
                 style == "link"
                     ? "underline mx-1 italic hover:text-blue-800"
                     : style == "none"
-                    ? "mx-1"
+                    ? "mx-2"
                     : `border-solid rounded-lg border-2 border-black/20 text-black/80 mr-2 p-2 ${
                           modalIsOpen && "hidden"
                       }`

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,28 +1,33 @@
 function Button({
-    style,
     modalIsOpen,
     buttonText,
     handleClick,
     type,
+    style,
+    extraStyle,
 }: {
     style?: string
+    extraStyle?: string
     modalIsOpen?: boolean
     buttonText: string
     handleClick?: (e: React.MouseEvent) => void
     type?: "button" | "submit" | "reset" | undefined
 }) {
+    const defaultStyle = `w-fit rounded-lg border-solid border-2 border-black/20 text-black/80 p-2 ${
+        modalIsOpen && "hidden"
+    }`
     return (
         <button
             type={type ? type : "button"}
             onClick={handleClick && handleClick}
             className={
                 style == "link"
-                    ? "underline mx-1 italic hover:text-blue-800"
+                    ? "underline w-fit mx-1 italic hover:text-blue-800"
                     : style == "none"
-                    ? "mx-2"
-                    : `border-solid rounded-lg border-2 border-black/20 text-black/80 mr-2 p-2 ${
-                          modalIsOpen && "hidden"
-                      }`
+                    ? "mx-4 w-fit"
+                    : style == "custom"
+                    ? `${defaultStyle} ${extraStyle}`
+                    : defaultStyle
             }
         >
             {buttonText}

--- a/components/EditorMenu.tsx
+++ b/components/EditorMenu.tsx
@@ -15,42 +15,54 @@ function EditorMenu({
     handleResetGridToDefault: (e: React.MouseEvent) => void
 }) {
     return (
-        <div className="flex items-center justify-center mb-4">
-            <div className="flex justify-between mb-4 border-x-2 border-b-2 rounded-md w-1/3 py-2 px-4">
-                <div className={!menuControlsOpen ? "hidden" : ""}>
+        <div className="flex justify-center mb-4">
+            <div
+                className={`flex justify-between border-x-2 border-b-2 rounded-b-md py-2 px-4 mb-4 ${
+                    !menuControlsOpen ? "w-auto" : "w-1/3"
+                }`}
+            >
+                <div className="flex justify-between w-full">
+                    <div
+                        className={
+                            !menuControlsOpen
+                                ? "hidden"
+                                : "flex justify-evenly w-full"
+                        }
+                    >
+                        <Button
+                            style="none"
+                            modalIsOpen={modalIsOpen}
+                            buttonText="Edit ✎"
+                            handleClick={() => {
+                                setModalOpen(!modalIsOpen)
+                            }}
+                        />
+                        <Button
+                            style="none"
+                            handleClick={handleResetGridToDefault}
+                            buttonText="New +"
+                        />
+                        <Button
+                            style="none"
+                            buttonText="Delete Grid"
+                            handleClick={(e) => {
+                                console.log("Deleting pattern")
+                            }}
+                        />
+                    </div>
+
                     <Button
                         style="none"
-                        modalIsOpen={modalIsOpen}
-                        buttonText="Edit ✎"
+                        buttonText={`${menuControlsOpen ? "X" : "Menu +"}`}
                         handleClick={() => {
-                            setModalOpen(!modalIsOpen)
-                        }}
-                    />
-                    <Button
-                        style="none"
-                        handleClick={handleResetGridToDefault}
-                        buttonText="New +"
-                    />
-                    <Button
-                        style="none"
-                        buttonText="Delete Grid"
-                        handleClick={(e) => {
-                            console.log("Deleting pattern")
+                            if (modalIsOpen) {
+                                setModalOpen(false)
+                            } else {
+                                setMenuOpen(!menuControlsOpen)
+                            }
                         }}
                     />
                 </div>
-
-                <Button
-                    style="none"
-                    buttonText={`${menuControlsOpen ? "X" : "Menu +"}`}
-                    handleClick={() => {
-                        if (modalIsOpen) {
-                            setModalOpen(false)
-                        } else {
-                            setMenuOpen(!menuControlsOpen)
-                        }
-                    }}
-                />
             </div>
         </div>
     )

--- a/components/EditorMenu.tsx
+++ b/components/EditorMenu.tsx
@@ -2,26 +2,50 @@ import { SetStateAction } from "react"
 import Button from "./Button"
 import { deletePixelGridServerAction } from "@/lib/actions"
 import { useGridContext } from "@/context/GridContext"
+import { usePixelIsFilled } from "@/hooks/usePixelFillState"
 
-function EditorMenu({
-    modalIsOpen,
-    menuControlsOpen,
-    setModalOpen,
-    setMenuOpen,
-    handleResetGridToDefault,
-}: {
-    modalIsOpen: boolean
-    menuControlsOpen: boolean
-    setModalOpen: React.Dispatch<SetStateAction<boolean>>
-    setMenuOpen: React.Dispatch<SetStateAction<boolean>>
-    handleResetGridToDefault: (e: React.MouseEvent) => void
-}) {
-    const { pattern } = useGridContext()
+function EditorMenu() {
+    const {
+        pattern,
+        menuControlsOpen,
+        setMenuOpen,
+        modalIsOpen,
+        setModalOpen,
+        defaultFillColor,
+        renderEmptyGrid,
+        setPixelFillColor,
+    } = useGridContext()
+    const { setPixelIsFilled, removePixelFill } = usePixelIsFilled()
+
+    function handleResetGridToDefault(e: React.MouseEvent) {
+        handleResetGridSize(e)
+        handleRemoveGridFill(e)
+        setPixelFillColor(defaultFillColor)
+    }
+
+    function handleResetGridSize(e: React.MouseEvent) {
+        e.preventDefault()
+        renderEmptyGrid()
+    }
+
+    function handleRemoveGridFill(e: React.MouseEvent) {
+        e.preventDefault()
+        let pixels = document.querySelectorAll(
+            ".grid-pixel"
+        ) as NodeListOf<HTMLDivElement>
+
+        pixels &&
+            pixels.forEach((p) => {
+                removePixelFill(p)
+                setPixelIsFilled(false)
+            })
+    }
+
     return (
         <div className="flex justify-center mb-4">
             <div
-                className={`flex justify-between border-x-2 border-b-2 rounded-b-md py-2 px-4 mb-4 ${
-                    !menuControlsOpen ? "w-auto" : "w-1/3"
+                className={`flex justify-between w-auto max-w-fit border-x-2 border-b-2 rounded-b-md py-2 px-4 mb-4 ${
+                    !menuControlsOpen ? "" : ""
                 }`}
             >
                 <div className="flex justify-between w-full">
@@ -42,18 +66,20 @@ function EditorMenu({
                         />
                         <Button
                             style="none"
-                            handleClick={handleResetGridToDefault}
-                            buttonText="New +"
+                            handleClick={handleRemoveGridFill}
+                            buttonText="Remove Fill"
                         />
                         <Button
                             style="none"
-                            buttonText="Delete Grid"
-                            handleClick={async (e) => {
-                                await deletePixelGridServerAction(pattern.id)
-                            }}
+                            handleClick={handleResetGridToDefault}
+                            buttonText="Reset Grid to Default"
                         />
+                        {/* <Button
+                            style="none"
+                            handleClick={handleResetGridSize}
+                            buttonText="Reset Size"
+                        /> */}
                     </div>
-
                     <Button
                         style="none"
                         buttonText={`${menuControlsOpen ? "X" : "Menu +"}`}

--- a/components/EditorMenu.tsx
+++ b/components/EditorMenu.tsx
@@ -1,5 +1,7 @@
 import { SetStateAction } from "react"
 import Button from "./Button"
+import { deletePixelGridServerAction } from "@/lib/actions"
+import { useGridContext } from "@/context/GridContext"
 
 function EditorMenu({
     modalIsOpen,
@@ -14,6 +16,7 @@ function EditorMenu({
     setMenuOpen: React.Dispatch<SetStateAction<boolean>>
     handleResetGridToDefault: (e: React.MouseEvent) => void
 }) {
+    const { pattern } = useGridContext()
     return (
         <div className="flex justify-center mb-4">
             <div
@@ -45,8 +48,8 @@ function EditorMenu({
                         <Button
                             style="none"
                             buttonText="Delete Grid"
-                            handleClick={(e) => {
-                                console.log("Deleting pattern")
+                            handleClick={async (e) => {
+                                await deletePixelGridServerAction(pattern.id)
                             }}
                         />
                     </div>

--- a/components/EditorMenu.tsx
+++ b/components/EditorMenu.tsx
@@ -15,34 +15,40 @@ function EditorMenu({
     handleResetGridToDefault: (e: React.MouseEvent) => void
 }) {
     return (
-        <div className="flex flex-row justify-center items-center mb-10">
-            <Button
-                buttonText={`${menuControlsOpen ? "-" : "Menu +"}`}
-                handleClick={() => {
-                    if (modalIsOpen) {
-                        setModalOpen(false)
-                    } else {
-                        setMenuOpen(!menuControlsOpen)
-                    }
-                }}
-            />
+        <div className="flex items-center justify-center mb-4">
+            <div className="flex justify-between mb-4 border-x-2 border-b-2 rounded-md w-1/3 py-2 px-4">
+                <div className={!menuControlsOpen ? "hidden" : ""}>
+                    <Button
+                        style="none"
+                        modalIsOpen={modalIsOpen}
+                        buttonText="Edit ✎"
+                        handleClick={() => {
+                            setModalOpen(!modalIsOpen)
+                        }}
+                    />
+                    <Button
+                        style="none"
+                        handleClick={handleResetGridToDefault}
+                        buttonText="New +"
+                    />
+                    <Button
+                        style="none"
+                        buttonText="Delete Grid"
+                        handleClick={(e) => {
+                            console.log("Deleting pattern")
+                        }}
+                    />
+                </div>
 
-            <div className={!menuControlsOpen ? "hidden" : ""}>
                 <Button
-                    modalIsOpen={modalIsOpen}
-                    buttonText="Edit ✎"
+                    style="none"
+                    buttonText={`${menuControlsOpen ? "X" : "Menu +"}`}
                     handleClick={() => {
-                        setModalOpen(!modalIsOpen)
-                    }}
-                />
-                <Button
-                    handleClick={handleResetGridToDefault}
-                    buttonText="New +"
-                />
-                <Button
-                    buttonText="Delete Grid"
-                    handleClick={(e) => {
-                        console.log("Deleting pattern")
+                        if (modalIsOpen) {
+                            setModalOpen(false)
+                        } else {
+                            setMenuOpen(!menuControlsOpen)
+                        }
                     }}
                 />
             </div>

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -9,7 +9,6 @@ function Grid() {
         currentPattern,
         setPattern,
         grid,
-        mouseIsDown,
         setMouseDownState,
         setFillOnDrag,
     } = useGridContext()

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -2,6 +2,7 @@
 import { useGridContext } from "@/context/GridContext"
 import { useEffect, useRef } from "react"
 import html2canvas from "html2canvas"
+import Button from "./Button"
 
 function Grid() {
     const {
@@ -54,26 +55,33 @@ function Grid() {
     }
 
     return (
-        <div onClick={handleClick}>
-            <header>
+        <div className="flex flex-col w-fit m-auto" onClick={handleClick}>
+            <div
+                className="flex justify-center"
+                id="grid"
+                aria-label="grid"
+                data-testid="grid"
+            >
                 <div
-                    className="flex justify-center"
-                    id="grid"
-                    aria-label="grid"
-                    data-testid="grid"
+                    style={{
+                        gridTemplateColumns: `repeat(${grid.length}, minmax(0, 1fr))`,
+                    }}
+                    className="border-solid border-2 grid rounded-lg"
+                    ref={ref}
                 >
-                    <div
-                        style={{
-                            gridTemplateColumns: `repeat(${grid.length}, minmax(0, 1fr))`,
-                        }}
-                        className="border-solid border-2 grid rounded-lg"
-                        ref={ref}
-                    >
-                        {grid.length && grid}
-                    </div>
+                    {grid.length && grid}
                 </div>
-            </header>
-            <button onClick={handleDownloadImage}>Download Img</button>
+            </div>
+            <div className="h-0"></div>
+
+            <div className="flex justify-end">
+                <Button
+                    style="custom"
+                    extraStyle="p-2 mt-4"
+                    handleClick={handleDownloadImage}
+                    buttonText="Download As Img"
+                />
+            </div>
         </div>
     )
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,7 +9,7 @@ const Header = () => {
     const pathname = usePathname()
 
     return (
-        <header className="flex items-center justify-between pb-10">
+        <header className="flex items-center justify-between p-4 w-full">
             <div>
                 <Link href="/" aria-label={siteMetadata.headerTitle}>
                     <div className="flex items-center justify-between">

--- a/components/PatternDetail.tsx
+++ b/components/PatternDetail.tsx
@@ -19,7 +19,6 @@ const PatternDetail = ({ authorized }: { authorized: boolean }) => {
                 )}
             </span>
             <div>
-                {/* <span>Id: {pattern.id}</span> */}
                 Title:{" "}
                 <span className="text-slate-500/75">
                     {authorized && currentPattern

--- a/components/PatternDetail.tsx
+++ b/components/PatternDetail.tsx
@@ -1,28 +1,43 @@
 "use client"
 import { useGridContext } from "@/context/GridContext"
+import Button from "./Button"
+import { deletePixelGridServerAction } from "@/lib/actions"
 
-const PatternDetail = () => {
+const PatternDetail = ({ authorized }: { authorized: boolean }) => {
     const { pattern, currentPattern, pixelFillColor } = useGridContext()
     return (
-        <div className="mt-4">
-            <div className="font-semibold">Current Pattern</div>
+        <div className="m-8">
+            <span className="inline-flex items-center my-2">
+                <h1 className="mr-4 font-semibold">Grid Details</h1>
+                {authorized && (
+                    <Button
+                        buttonText="Delete Grid"
+                        handleClick={async (e) => {
+                            await deletePixelGridServerAction(pattern.id)
+                        }}
+                    />
+                )}
+            </span>
             <div>
+                {/* <span>Id: {pattern.id}</span> */}
                 Title:{" "}
                 <span className="text-slate-500/75">
-                    {currentPattern
+                    {authorized && currentPattern
                         ? pattern.title
-                        : "You Haven't Named Your Pattern Yet!"}
+                        : authorized && !currentPattern
+                        ? "Untitled"
+                        : "Create an Account to Name & Save Your Grid"}
                 </span>
             </div>
             <div>
                 Height:{" "}
-                <span className="text-slate-500/75">{pattern.gridHeight}</span>
-            </div>
-            <div>
+                <span className="text-slate-500/75 mr-4">
+                    {pattern.gridHeight}
+                </span>
                 Width:{" "}
-                <span className="text-slate-500/75">{pattern.gridWidth}</span>
-            </div>
-            <div>
+                <span className="text-slate-500/75 mr-4">
+                    {pattern.gridWidth}
+                </span>
                 Color:{" "}
                 <span className="text-slate-500/75">{pixelFillColor}</span>
             </div>

--- a/components/PatternForm.tsx
+++ b/components/PatternForm.tsx
@@ -1,9 +1,11 @@
 "use client"
 import { useGridContext } from "@/context/GridContext"
-import { usePixelIsFilled } from "@/hooks/usePixelFillState"
 import Button from "@/components/Button"
 
-import { createPixelGridServerAction } from "@/lib/actions"
+import {
+    createPixelGridServerAction,
+    updatePixelGridServerAction,
+} from "@/lib/actions"
 import { useState } from "react"
 import Modal from "@/components/Modal"
 import ColorWheel from "./ColorWheel"
@@ -27,6 +29,11 @@ function PatternForm({ authorized }: { authorized: boolean }) {
     const saveGrid = createPixelGridServerAction.bind(
         null,
         pixels as unknown as FormData
+    )
+    const updateGrid = updatePixelGridServerAction.bind(
+        null,
+        pixels as unknown as FormData,
+        pattern.id
     )
 
     function handlePatternFormChange(e: React.FormEvent) {
@@ -89,18 +96,23 @@ function PatternForm({ authorized }: { authorized: boolean }) {
         if (authorized) {
             const form = document.getElementById("form") as HTMLFormElement
 
+            // TODO: Error-handling refactor
             if (!data.get("title")) {
-                console.log("Whoops! Please add a title and try again.")
                 setFormText("Whoops! Please add a title and try again.")
                 setFormError(true)
             } else if (menuControlsOpen && modalIsOpen) {
                 try {
-                    await saveGrid(data)
+                    setFormText("Saving Your Changes..")
+                    if (pattern.id) {
+                        updateGrid(data)
+                    } else if (!pattern.id || pattern.id == null) {
+                        await saveGrid(data)
+                    }
                 } catch (e) {
-                    console.log("Error Message:", e)
-                    throw new Error(
+                    setFormText(
                         "There was a problem saving your grid to the database. Try again later."
                     )
+                    setFormError(true)
                 } finally {
                     form && form.reset()
                     setFormError(false)
@@ -115,16 +127,12 @@ function PatternForm({ authorized }: { authorized: boolean }) {
                 )
             } catch (e) {
                 throw new Error(
-                    "There was a problem saving your grid to the database. Try again later."
+                    "There was an unexpected problem accessing the database. Please check the logs for more information."
                 )
             } finally {
                 setFormError(false)
             }
         }
-    }
-
-    function handleUpdateCurrentPattern(e: React.MouseEvent) {
-        console.log("Updating Pattern")
     }
 
     return (
@@ -142,21 +150,6 @@ function PatternForm({ authorized }: { authorized: boolean }) {
                         >
                             <>
                                 <div>
-                                    {/* <label htmlFor="title">Title</label> */}
-                                    {/* <input
-                                        className="hidden"
-                                        name="pixelGridId"
-                                        type="text"
-                                        aria-label="pixelGridId"
-                                        placeholder="Grid Id"
-                                        value={
-                                            pattern.id
-                                                ? pattern.id
-                                                : "Missing ID error"
-                                        }
-                                        onChange={handlePatternFormChange}
-                                    /> */}
-
                                     <label htmlFor="title">Title</label>
                                     <input
                                         className="text-slate-600 border-2 border-black/10 rounded-md w-1/4 m-2"

--- a/components/PatternForm.tsx
+++ b/components/PatternForm.tsx
@@ -9,7 +9,7 @@ import Modal from "@/components/Modal"
 import ColorWheel from "./ColorWheel"
 import EditorMenu from "./EditorMenu"
 
-function PatternForm() {
+function PatternForm({ authorized }: { authorized: boolean }) {
     const {
         pattern,
         setPattern,
@@ -115,24 +115,39 @@ function PatternForm() {
     }
 
     async function handleSubmit(data: FormData) {
-        const form = document.getElementById("form") as HTMLFormElement
+        if (authorized) {
+            const form = document.getElementById("form") as HTMLFormElement
 
-        if (!data.get("title")) {
-            console.log("Whoops! Please add a title and try again.")
-            setFormText("Whoops! Please add a title and try again.")
-            setFormError(true)
-        } else if (menuControlsOpen && modalIsOpen) {
+            if (!data.get("title")) {
+                console.log("Whoops! Please add a title and try again.")
+                setFormText("Whoops! Please add a title and try again.")
+                setFormError(true)
+            } else if (menuControlsOpen && modalIsOpen) {
+                try {
+                    await saveGrid(data)
+                } catch (e) {
+                    console.log("Error Message:", e)
+                    throw new Error(
+                        "There was a problem saving your grid to the database. Try again later."
+                    )
+                } finally {
+                    form && form.reset()
+                    setFormError(false)
+                    setFormText("Saved!")
+                }
+            }
+        } else {
             try {
-                await saveGrid(data)
+                setFormError(true)
+                setFormText(
+                    "You must be logged in to save your pixel grid. Please log in and try again. "
+                )
             } catch (e) {
-                console.log("Error Message:", e)
                 throw new Error(
                     "There was a problem saving your grid to the database. Try again later."
                 )
             } finally {
-                form && form.reset()
                 setFormError(false)
-                setFormText("Saved!")
             }
         }
     }
@@ -218,15 +233,12 @@ function PatternForm() {
                             </>
 
                             <div className="m-4 ml-0">
-                                <Button
-                                    handleClick={handleRemoveGridFill}
-                                    buttonText="Remove Pixel Fill"
-                                />
-                                <Button
-                                    handleClick={handleResetGridSize}
-                                    buttonText="Reset Size"
-                                />
-                                <Button type="submit" buttonText="Save Grid" />
+                                {authorized && (
+                                    <Button
+                                        type="submit"
+                                        buttonText="Save Grid"
+                                    />
+                                )}
                             </div>
                         </form>
                     </Modal>

--- a/components/PatternForm.tsx
+++ b/components/PatternForm.tsx
@@ -3,7 +3,7 @@ import { useGridContext } from "@/context/GridContext"
 import { usePixelIsFilled } from "@/hooks/usePixelFillState"
 import Button from "@/components/Button"
 
-import { createPatternServerAction } from "@/lib/actions"
+import { createPixelGridServerAction } from "@/lib/actions"
 import { useState } from "react"
 import Modal from "@/components/Modal"
 import ColorWheel from "./ColorWheel"
@@ -29,7 +29,7 @@ function PatternForm() {
     const [formSaveText, setFormText] = useState<string | null>(null)
 
     const pixels = pattern.pixels
-    const saveGrid = createPatternServerAction.bind(
+    const saveGrid = createPixelGridServerAction.bind(
         null,
         pixels as unknown as FormData
     )

--- a/components/PatternForm.tsx
+++ b/components/PatternForm.tsx
@@ -14,15 +14,10 @@ function PatternForm({ authorized }: { authorized: boolean }) {
         pattern,
         setPattern,
         setPixelFillColor,
-        renderEmptyGrid,
         maxGridWidth,
-        defaultFillColor,
+        menuControlsOpen,
+        modalIsOpen,
     } = useGridContext()
-    const { setPixelIsFilled, removePixelFill } = usePixelIsFilled()
-
-    // CONTROLS
-    const [modalIsOpen, setModalOpen] = useState(false)
-    const [menuControlsOpen, setMenuOpen] = useState(true)
 
     // FORM STATE
     const [formError, setFormError] = useState(false)
@@ -33,30 +28,6 @@ function PatternForm({ authorized }: { authorized: boolean }) {
         null,
         pixels as unknown as FormData
     )
-
-    function handleResetGridToDefault(e: React.MouseEvent) {
-        handleResetGridSize(e)
-        handleRemoveGridFill(e)
-        setPixelFillColor(defaultFillColor)
-    }
-
-    function handleResetGridSize(e: React.MouseEvent) {
-        e.preventDefault()
-        renderEmptyGrid()
-    }
-
-    function handleRemoveGridFill(e: React.MouseEvent) {
-        e.preventDefault()
-        let pixels = document.querySelectorAll(
-            ".grid-pixel"
-        ) as NodeListOf<HTMLDivElement>
-
-        pixels &&
-            pixels.forEach((p) => {
-                removePixelFill(p)
-                setPixelIsFilled(false)
-            })
-    }
 
     function handlePatternFormChange(e: React.FormEvent) {
         const target = e.target as HTMLInputElement
@@ -158,13 +129,7 @@ function PatternForm({ authorized }: { authorized: boolean }) {
 
     return (
         <>
-            <EditorMenu
-                menuControlsOpen={menuControlsOpen}
-                modalIsOpen={modalIsOpen}
-                setModalOpen={setModalOpen}
-                setMenuOpen={setMenuOpen}
-                handleResetGridToDefault={handleResetGridToDefault}
-            />
+            <EditorMenu />
             <Modal isOpen={!formSaveText ? false : true}>{formSaveText}</Modal>
 
             {menuControlsOpen && modalIsOpen && (
@@ -173,11 +138,11 @@ function PatternForm({ authorized }: { authorized: boolean }) {
                         <form
                             id="form"
                             action={async (data) => await handleSubmit(data)}
-                            className="flex flex-col justify-between w-3/4 my-4"
+                            className="flex flex-col justify-between w-3/4"
                         >
                             <>
                                 <div>
-                                    <label htmlFor="title">Title</label>
+                                    {/* <label htmlFor="title">Title</label> */}
                                     {/* <input
                                         className="hidden"
                                         name="pixelGridId"

--- a/context/GridContext.tsx
+++ b/context/GridContext.tsx
@@ -43,6 +43,7 @@ export default function ContextProvider({
 
     /** Pattern State */
     const [pattern, setPattern] = useState<Pattern>({
+        id: "",
         title: "",
         gridHeight: defaultGridHeight,
         gridWidth: defaultGridWidth,
@@ -67,6 +68,7 @@ export default function ContextProvider({
             )
 
             setPattern({
+                id: "",
                 title: "",
                 gridHeight: defaultGridHeight,
                 gridWidth: defaultGridWidth,

--- a/context/GridContext.tsx
+++ b/context/GridContext.tsx
@@ -31,6 +31,10 @@ export default function ContextProvider({
         )
     )
 
+    /** Editor Menu State */
+    const [modalIsOpen, setModalOpen] = useState(false)
+    const [menuControlsOpen, setMenuOpen] = useState(true)
+
     /** Grid State */
     const [mouseIsDown, setMouseDownState] = useState(false)
     const [fillWhenDragged, setFillOnDrag] = useState(false)
@@ -121,6 +125,10 @@ export default function ContextProvider({
 
     /** Export Stuff */
     const ctx: GridContextType = {
+        modalIsOpen,
+        setModalOpen,
+        menuControlsOpen,
+        setMenuOpen,
         mouseIsDown,
         setMouseDownState,
         maxGridWidth,

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -69,7 +69,6 @@ export async function createPixelGridServerAction(
 
 export async function deletePixelGridServerAction(id: string) {
     const user = await getUserByClerkId()
-    console.log("ID is: ", id)
 
     if (user) {
         try {

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -67,6 +67,45 @@ export async function createPixelGridServerAction(
     }
 }
 
+export async function updatePixelGridServerAction(
+    pixels: FormData,
+    id: string,
+    formData: FormData
+) {
+    const user = await getUserByClerkId()
+    const title = formData.get("title") as string
+    const width = formData.get("gridWidth")
+    const height = formData.get("gridHeight")
+
+    if (user) {
+        try {
+            await db.pattern.upsert({
+                where: {
+                    id,
+                    userId: user.id,
+                },
+                update: {
+                    title,
+                    gridWidth: Number(width) || DEFAULTGRIDHEIGHT,
+                    gridHeight: Number(height) || DEFAULTGRIDWIDTH,
+                    pixels: pixels as unknown as string,
+                },
+                create: {
+                    title,
+                    gridWidth: Number(width) || DEFAULTGRIDHEIGHT,
+                    gridHeight: Number(height) || DEFAULTGRIDWIDTH,
+                    pixels: pixels as unknown as string,
+                    userId: user.id,
+                },
+            })
+        } catch (e) {
+            console.log("There was an error in update server action", e)
+        } finally {
+            revalidatePath("/pattern")
+        }
+    }
+}
+
 export async function deletePixelGridServerAction(id: string) {
     const user = await getUserByClerkId()
 

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -39,7 +39,7 @@ export const createNewUser = async (path: string | undefined = undefined) => {
     }
 }
 
-export async function createPatternServerAction(
+export async function createPixelGridServerAction(
     pixels: FormData,
     formData: FormData
 ) {
@@ -61,6 +61,28 @@ export async function createPatternServerAction(
             })
         } catch (e) {
             console.log("There was an error in create pattern server action", e)
+        } finally {
+            revalidatePath("/pattern")
+        }
+    }
+}
+
+export async function deletePixelGridServerAction(id: string) {
+    const user = await getUserByClerkId()
+    console.log("ID is: ", id)
+
+    if (user) {
+        try {
+            await db.pattern.delete({
+                where: {
+                    id,
+                },
+            })
+        } catch (e) {
+            console.log(
+                "An error occurred while deleting your pixel grid - from delete server action",
+                e
+            )
         } finally {
             revalidatePath("/pattern")
         }

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,7 +4,7 @@ import { authMiddleware } from "@clerk/nextjs"
 // Please edit this to allow other routes to be public as needed.
 // See https://clerk.com/docs/references/nextjs/auth-middleware for more information about configuring your Middleware
 export default authMiddleware({
-    publicRoutes: ["/", "/faq", "/templates"],
+    publicRoutes: ["/", "/pattern", "/faq", "/templates"],
 })
 
 export const config = {

--- a/types/context.ts
+++ b/types/context.ts
@@ -2,6 +2,10 @@ import { SetStateAction } from "react"
 import { Pattern } from "./pattern"
 
 export type GridContextType = {
+    modalIsOpen: boolean
+    setModalOpen: React.Dispatch<SetStateAction<boolean>>
+    menuControlsOpen: boolean
+    setMenuOpen: React.Dispatch<SetStateAction<boolean>>
     mouseIsDown: boolean
     setFillOnDrag: React.Dispatch<SetStateAction<boolean>>
     fillWhenDragged: boolean

--- a/types/pattern.ts
+++ b/types/pattern.ts
@@ -1,4 +1,5 @@
 export type Pattern = {
+    id: string
     title: string | undefined
     gridWidth: number | undefined
     gridHeight: number | undefined


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
|  | Bug Fix |
|✔️| New Feature  |
|✔️| Refactor  |
| | Update Deps  |
| | Documentation  |

### Description
---
## **⚙️ Refactor Changes**
### Tidying Up
- Remove unused imports/statements from Grid Component

## **✨ New Feature Changes**
### CRUD Implementation
  - Added an `updateGrid` function to server actions and **PatternForm**, uses Prisma `upsert` to update the existing db record if it can be found by id. Otherwise, a new db record will be created if no matching grid is found.
  - Added `deleteGrid` to server actions and **PatternForm** for deleting a db pixel grid. Required adding a grid ID to the Context details, that will then be passed to the delete function for querying the db / deleting the correct pattern. User must be logged into their account to delete a pattern from the db.

### Editor Menu Component
  - Lifted modal and menu controls state to the **GridContext** so they can be used by multiple components across the **Editor**.
  - Moved the Reset Grid controls from **PatternForm** to the **EditorMenu** component
  - Added additional `extraStyle` prop and button types to the Button component to allow styling on the fly, extracted the default style to it’s own variable within the Button component so that it can be easily extended/applied to different button types.
  - Fixed Menu Controls bar and Download Image button styles so the **Editor** looks more polished.
  - Removed default button styles from **EditorMenu** buttons, adjusted the padding and border width/styles so that the controls look like one cohesive "menu bar", instead of a series of individual buttons.
  - Added a horizontal border to the layout Header so that the Editor Menu will look like its sliding out from beneath it. Still need to add animations for this transition, and need to adjust styles so that when the controls are collapsed the width decreases.
  - Added additional flex and width tailwind classes to Editor Menu divs for styling. Menu width and button placement look different based on whether the menu bar is collapsed or expanded.

### Protected Routes
  - Added the `/pattern` route to the public routes list, to allow a guest user (user who is not logged in) to use the **Editor** and download their pixel grid as an image if they opt out of signing up for an account.
  - Created a new **'authorized'** prop that can be passed around to **Grid** components without requiring a conversion to client component. _Using this in the **PatternForm** and **PatternDetail** to conditionally render buttons for logged in actions like Saving to or Deleting from the database. A guest user won't see the option to save or delete their grid anymore, but they will see the option to download their grid as  a PNG image._

### To-Dos
---
- [ ] Save current image of the grid to the db for use as a preview (in the Library carousel, for example. Could act as cover image for the pixel grid cards.)
- [ ] Move away from calling anything a ‘pattern’ or naming things in relation to ‘patterns’, since this is a mis-representation of what the user is creating when they use the Editor. Will plan to slowly/progressively rename things to ‘pixel grid’ or ‘grid’. This includes the `/pattern` route. 
- [ ] Update Menu Bar buttons to use icons instead of text descriptions.