### PR TITLE
Modal Overlay

### DIFF
--- a/app/symbols/page.tsx
+++ b/app/symbols/page.tsx
@@ -1,40 +1,15 @@
-import { convertSVGs } from "@/lib/images"
-import { SVGType } from "@/types/images"
-import Image from "next/image"
-const reqSvgs = require.context("@/public/symbols/svg", true, /\.\/(.+)\.svg$/)
-
-const IMAGE_WIDTH = 25
-const IMAGE_HEIGHT = 25
+import ChartSymbolsList from "@/components/ChartSymbols"
 
 function Page() {
     return (
-        <div className="ml-16">
-            <div className="p-4">
+        <>
+            <div className="p-4 ml-16">
                 <h1>Knitting Chart Symbols</h1>
 
                 <span>Dropdown for craft type here TODO ⇣</span>
             </div>
-
-            {/* Add more symbols TODO */}
-            {/* Figure out how to format the string names TODO */}
-            {convertSVGs(reqSvgs).map((svg: SVGType, index: number) => (
-                <div key={index} className="p-2 m-2 w-fit">
-                    <div className="flex flex-row">
-                        <div className="p-2 border-solid border-2 border-grey-200 rounded-sm">
-                            <Image
-                                src={`${svg.svg.default.src}`}
-                                width={IMAGE_WIDTH}
-                                height={IMAGE_HEIGHT}
-                                className="aspect-square"
-                                alt={`chart-symbol-${index}`}
-                            />
-                        </div>
-                        <span className="ml-4"> |</span>
-                        <span className="ml-4"> {svg.name}</span>
-                    </div>
-                </div>
-            ))}
-        </div>
+            <ChartSymbolsList />
+        </>
     )
 }
 

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,5 +1,4 @@
 function Button({
-    modalIsOpen,
     buttonText,
     handleClick,
     type,
@@ -9,15 +8,13 @@ function Button({
 }: {
     style?: string
     extraStyle?: string
-    modalIsOpen?: boolean
     buttonText: string
     handleClick?: (e: React.MouseEvent) => void
     type?: "button" | "submit" | "reset" | undefined
     children?: React.ReactNode
 }) {
-    const defaultStyle = `w-fit rounded-lg border-solid border-2 border-black/20 text-black/80 p-2 ${
-        modalIsOpen && "hidden"
-    }`
+    const defaultStyle = `w-fit rounded-lg border-solid border-2 border-black/20 text-black/80 p-2`
+
     return (
         <button
             type={type ? type : "button"}

--- a/components/ChartDetail.tsx
+++ b/components/ChartDetail.tsx
@@ -1,49 +1,12 @@
 "use client"
 import { useGridContext } from "@/context/GridContext"
-import Button from "./Button"
-import { deletePixelGridServerAction } from "@/lib/actions"
-import Modal from "./Modal"
-import { useState } from "react"
 
 const ChartDetail = ({ authorized }: { authorized: boolean }) => {
     const { chart, chartFromDatabase, pixelFillColor } = useGridContext()
-    const [open, setOpen] = useState(false) // organize modal states, Grid uses another, formError yet another
 
     return (
         <div className="my-8">
-            <Modal isOpen={open}>
-                Are you sure you want to delete this chart? This action cannot
-                be undone.
-                <Button
-                    style="customWithDefaults"
-                    extraStyle="mx-2 text-red-800 border-red-800 hover:bg-red-800"
-                    buttonText="Yes"
-                    handleClick={async (e) => {
-                        setOpen(false)
-                        await deletePixelGridServerAction(chart.id)
-                    }}
-                />
-                <Button
-                    buttonText="Cancel"
-                    style="customWithDefaults"
-                    extraStyle="mx-2 text-gray-800 border-gray-800 hover:bg-gray-800"
-                    handleClick={() => {
-                        setOpen(false)
-                    }}
-                />
-            </Modal>
-
-            <span className="inline-flex items-center my-2">
-                <h1 className="my-4 mr-4 font-semibold">Grid Details</h1>
-                {authorized && (
-                    <Button
-                        style="custom"
-                        extraStyle="py-2 px-3 border-2 rounded-[55%]"
-                        buttonText="❌"
-                        handleClick={async (e) => setOpen(true)}
-                    />
-                )}
-            </span>
+            <h1 className="font-semibold">Grid Details</h1>
             <div>
                 Title:{" "}
                 <span className="text-slate-500/75">

--- a/components/ChartSymbolsList.tsx
+++ b/components/ChartSymbolsList.tsx
@@ -1,0 +1,32 @@
+import { SVG_SYMBOL_HEIGHT, SVG_SYMBOL_WIDTH } from "@/lib/globals"
+import { convertSVGs } from "@/lib/images"
+import { SVGType } from "@/types/images"
+import Image from "next/image"
+const reqSvgs = require.context("@/public/symbols/svg", true, /\.\/(.+)\.svg$/)
+
+const ChartSymbolsList = () => {
+    return (
+        <div className="ml-16">
+            {/* Add more symbols TODO */}
+            {/* Figure out how to format the string names TODO */}
+            {convertSVGs(reqSvgs).map((svg: SVGType, index: number) => (
+                <div key={index} className="p-2 m-2 w-fit">
+                    <div className="flex flex-row">
+                        <div className="p-2 border-solid border-2 border-grey-200 rounded-sm">
+                            <Image
+                                src={`${svg.svg.default.src}`}
+                                width={SVG_SYMBOL_WIDTH}
+                                height={SVG_SYMBOL_HEIGHT}
+                                className="aspect-square"
+                                alt={`chart-symbol-${index}`}
+                            />
+                        </div>
+                        <span className="ml-4"> |</span>
+                        <span className="ml-4"> {svg.name}</span>
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+}
+export default ChartSymbolsList

--- a/components/ColorWheel.tsx
+++ b/components/ColorWheel.tsx
@@ -2,10 +2,16 @@ import { useGridContext } from "@/context/GridContext"
 import { Sketch } from "@uiw/react-color"
 // import { Alpha, Hue, ShadeSlider, Saturation, Interactive, hsvaToHslaString } from '@uiw/react-color';
 // import { EditableInput, EditableInputRGBA, EditableInputHSLA } from '@uiw/react-color';
-import { useState } from "react"
+import { SetStateAction, useState } from "react"
 import Button from "./Button"
 
-function ColorWheel({ disabled }: { disabled: boolean }) {
+function ColorWheel({
+    disabled,
+    setOpen,
+}: {
+    disabled: boolean
+    setOpen: React.Dispatch<SetStateAction<boolean>>
+}) {
     const { pixelFillColor, setPixelFillColor, defaultFillColor } =
         useGridContext()
     const [hex, setHex] = useState(pixelFillColor)
@@ -19,6 +25,7 @@ function ColorWheel({ disabled }: { disabled: boolean }) {
                     handleClick={() => {
                         setHex(defaultFillColor)
                         setPixelFillColor(defaultFillColor)
+                        setOpen(false)
                     }}
                 />
             </div>

--- a/components/EditorForm.tsx
+++ b/components/EditorForm.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/lib/actions"
 import { useState } from "react"
 import Modal from "@/components/Modal"
-import ColorWheel from "./ColorWheel"
+
 import EditorMenu from "./EditorMenu"
 
 function EditorForm({ authorized }: { authorized: boolean }) {
@@ -19,8 +19,8 @@ function EditorForm({ authorized }: { authorized: boolean }) {
         setPixelFillColor,
         maxGridWidth,
         menuControlsOpen,
-        modalIsOpen,
     } = useGridContext()
+    const [modalIsOpen, setModalOpen] = useState(false)
 
     // FORM STATE
     const [formError, setFormError] = useState(false)
@@ -108,6 +108,7 @@ function EditorForm({ authorized }: { authorized: boolean }) {
                         updateGrid(data)
                     } else if (!chart.id || chart.id == null) {
                         await saveGrid(data)
+                        setFormText("Saved!")
                     }
                 } catch (e) {
                     setFormText(
@@ -116,8 +117,11 @@ function EditorForm({ authorized }: { authorized: boolean }) {
                     setFormError(true)
                 } finally {
                     form && form.reset()
+                    setModalOpen(false)
                     setFormError(false)
-                    setFormText("Saved!")
+                    setInterval(() => {
+                        setFormText(null)
+                    }, 3000)
                 }
             }
         } else {
@@ -138,23 +142,23 @@ function EditorForm({ authorized }: { authorized: boolean }) {
 
     return (
         <>
-            <EditorMenu />
-            <Modal isOpen={!formSaveText ? false : true}>{formSaveText}</Modal>
+            <EditorMenu modalIsOpen={modalIsOpen} setModalOpen={setModalOpen} />
+            {/* <Modal isOpen={!formSaveText ? false : true}>{formSaveText}</Modal> */}
 
             {menuControlsOpen && modalIsOpen && (
                 <div className="flex flex-row justify-center items-center">
-                    <Modal isOpen={modalIsOpen}>
+                    <Modal isOpen={modalIsOpen} setOpen={setModalOpen}>
                         <form
                             id="form"
                             action={async (data) => await handleSubmit(data)}
-                            className="flex flex-col justify-between w-3/4"
+                            className="flex flex-col justify-between items-center w-3/4"
                         >
                             <>
                                 <ChartDetail authorized={authorized} />
                                 <div>
                                     <label htmlFor="title">Title</label>
                                     <input
-                                        className="text-slate-600 border-2 border-black/10 rounded-md w-1/4 m-2"
+                                        className="text-slate-600 border-2 border-black/10 rounded-md w-fit m-2"
                                         name="title"
                                         id="title"
                                         type="text"
@@ -164,37 +168,38 @@ function EditorForm({ authorized }: { authorized: boolean }) {
                                         onChange={handleChartFormChange}
                                     />
 
-                                    <label htmlFor="grid-height">Height</label>
-                                    <input
-                                        className="text-slate-600 border-2 border-black/10 rounded-md w-1/6 m-2"
-                                        name="gridHeight"
-                                        type="number"
-                                        aria-label="gridHeight"
-                                        onChange={handleChartFormChange}
-                                        placeholder="Height in Pixels"
-                                    />
-
-                                    <label htmlFor="grid-width">Width</label>
-                                    <input
-                                        className="text-slate-600 border-2 border-black/10 rounded-md w-1/6 m-2"
-                                        name="gridWidth"
-                                        type="number"
-                                        aria-label="gridWidth"
-                                        onChange={handleChartFormChange}
-                                        placeholder="Width in Pixels"
-                                    />
+                                    <div>
+                                        <label htmlFor="grid-height">
+                                            Height
+                                        </label>
+                                        <input
+                                            className="text-slate-600 border-2 border-black/10 rounded-md w-1/6 m-2"
+                                            name="gridHeight"
+                                            type="number"
+                                            aria-label="gridHeight"
+                                            onChange={handleChartFormChange}
+                                            placeholder="Height in Pixels"
+                                        />
+                                        <label htmlFor="grid-width">
+                                            Width
+                                        </label>
+                                        <input
+                                            className="text-slate-600 border-2 border-black/10 rounded-md w-1/6 m-2"
+                                            name="gridWidth"
+                                            type="number"
+                                            aria-label="gridWidth"
+                                            onChange={handleChartFormChange}
+                                            placeholder="Width in Pixels"
+                                        />
+                                    </div>
                                 </div>
-
-                                <ColorWheel
-                                    disabled={!modalIsOpen || !menuControlsOpen}
-                                />
                             </>
 
                             <div className="m-4 ml-0">
                                 {authorized && (
                                     <Button
                                         type="submit"
-                                        buttonText="Save Grid"
+                                        buttonText="Save Changes →"
                                     />
                                 )}
                             </div>

--- a/components/EditorMenu.tsx
+++ b/components/EditorMenu.tsx
@@ -185,6 +185,7 @@ function EditorMenu({
                             setOpen={setColorWheelOpen}
                         >
                             <ColorWheel
+                                setOpen={setColorWheelOpen}
                                 disabled={!colorwheelOpen || !menuControlsOpen}
                             />
                         </Modal>

--- a/components/EditorMenu.tsx
+++ b/components/EditorMenu.tsx
@@ -1,21 +1,88 @@
-import { SetStateAction } from "react"
+"use client"
+import { SetStateAction, useState } from "react"
 import Button from "./Button"
-import { deletePixelGridServerAction } from "@/lib/actions"
 import { useGridContext } from "@/context/GridContext"
 import { usePixelIsFilled } from "@/hooks/usePixelFillState"
+import Modal from "./Modal"
+import { deletePixelGridServerAction } from "@/lib/actions"
+import ColorWheel from "./ColorWheel"
 
-function EditorMenu() {
+function EditorMenu({
+    modalIsOpen,
+    setModalOpen,
+}: {
+    modalIsOpen: boolean
+    setModalOpen: React.Dispatch<SetStateAction<boolean>>
+}) {
     const {
         chart,
         menuControlsOpen,
         setMenuOpen,
-        modalIsOpen,
-        setModalOpen,
         defaultFillColor,
         renderEmptyGrid,
         setPixelFillColor,
     } = useGridContext()
+
+    const [open, setOpen] = useState(false)
     const { setPixelIsFilled, removePixelFill } = usePixelIsFilled()
+    const [colorwheelOpen, setColorWheelOpen] = useState(false)
+
+    var buttons = [
+        {
+            type: "select",
+            value: "Mode",
+            options: ["Mode", "Fill", "Erase", "Paste"],
+            handleClick: () => {
+                // setPMOpen(!paintModeOpen)
+            },
+            style: "none",
+        },
+        {
+            type: "button",
+            value: "Color",
+            handleClick: () => setColorWheelOpen(!colorwheelOpen),
+            style: "none",
+        },
+        {
+            type: "button",
+            value: "Remove Fill",
+            handleClick: handleRemoveGridFill,
+            style: "none",
+        },
+        {
+            type: "button",
+            value: "Reset Size",
+            handleClick: handleResetGridSize,
+            style: "none",
+        },
+        {
+            type: "button",
+            value: "New",
+            handleClick: handleResetGridToDefault,
+            style: "none",
+        },
+
+        {
+            type: "button",
+            value: "Delete", // only show this if rendering a saved chart TODO
+            handleClick: () => {
+                setOpen(!open)
+            },
+            modalIsOpen: modalIsOpen,
+            style: "none",
+        },
+        {
+            type: "button",
+            value: "Save",
+            handleClick: () => {
+                setModalOpen(!modalIsOpen)
+            },
+            modalIsOpen: modalIsOpen,
+            style: "none",
+        },
+
+        // { value: "", handleClick: () => {}, modalIsOpen: null, style: "" },
+    ]
 
     function handleResetGridToDefault(e: React.MouseEvent) {
         handleResetGridSize(e)
@@ -41,8 +108,65 @@ function EditorMenu() {
             })
     }
 
+    const links =
+        buttons &&
+        buttons.map((link, index) => {
+            if (link.type === "button") {
+                return (
+                    <Button
+                        style={link.style}
+                        handleClick={link.handleClick}
+                        buttonText={link.value}
+                        key={index}
+                    />
+                )
+            } else if (link.type === "select") {
+                return (
+                    <select name="mode" key={index}>
+                        {link.options &&
+                            link.options.map((text, index) => {
+                                return (
+                                    <option key={index} value={text}>
+                                        {text}
+                                    </option>
+                                )
+                            })}
+                    </select>
+                )
+            }
+        })
+
     return (
-        <div className="flex min-w-screen justify-center mb-4">
+        <div className="flex justify-center min-w-screen mb-4">
+            <Modal isOpen={open} setOpen={setOpen}>
+                <div className="flex flex-col justify-center items-center">
+                    <div className="flex justify-center items-center p-8">
+                        Are you sure you want to delete this chart? This action
+                        cannot be undone.
+                    </div>
+                    <div className="flex justify-center items-center m-8">
+                        <Button
+                            style="customWithDefaults"
+                            extraStyle="mx-2 text-red-800 border-red-800 hover:bg-red-800"
+                            buttonText="Yes"
+                            handleClick={async (e) => {
+                                setOpen(false)
+                                await handleResetGridToDefault(e)
+                                await deletePixelGridServerAction(chart.id)
+                            }}
+                        />
+                        <Button
+                            buttonText="Cancel"
+                            style="customWithDefaults"
+                            extraStyle="mx-2 text-gray-800 border-gray-800 hover:bg-gray-800"
+                            handleClick={() => {
+                                setOpen(false)
+                            }}
+                        />
+                    </div>
+                </div>
+            </Modal>
+
             <div
                 className={`flex justify-between w-auto max-w-fit border-x-2 border-b-2 rounded-b-md py-2 px-4 mb-4 ${
                     !menuControlsOpen ? "" : ""
@@ -56,29 +180,15 @@ function EditorMenu() {
                                 : "flex justify-evenly w-full"
                         }
                     >
-                        <Button
-                            style="none"
-                            modalIsOpen={modalIsOpen}
-                            buttonText="Edit ✎"
-                            handleClick={() => {
-                                setModalOpen(!modalIsOpen)
-                            }}
-                        />
-                        <Button
-                            style="none"
-                            handleClick={handleRemoveGridFill}
-                            buttonText="Remove Fill"
-                        />
-                        <Button
-                            style="none"
-                            handleClick={handleResetGridToDefault}
-                            buttonText="Start Over"
-                        />
-                        {/* <Button
-                            style="none"
-                            handleClick={handleResetGridSize}
-                            buttonText="Reset Size"
-                        /> */}
+                        <Modal
+                            isOpen={colorwheelOpen}
+                            setOpen={setColorWheelOpen}
+                        >
+                            <ColorWheel
+                                disabled={!colorwheelOpen || !menuControlsOpen}
+                            />
+                        </Modal>
+                        {links && links}
                     </div>
                     <Button
                         style="none"

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,18 +1,51 @@
+"use client"
+import { SetStateAction } from "react"
+import Button from "./Button"
+
 const Modal = ({
     isOpen,
+    setOpen,
     children,
 }: {
     isOpen: boolean
-    children: React.ReactNode
+    setOpen?: React.Dispatch<SetStateAction<boolean>>
+    children?: React.ReactNode
 }) => {
-    return (
-        <div
-            className={`${
-                isOpen ? "opactity-100 h-fit" : "opacity-0 h-0"
-            } transition-all ease-in-out delay-100 duration-250`}
-        >
-            {children}
-        </div>
-    )
+    // Default Styles
+    var hidden = "opacity-0 h-0"
+    var visible = "h-fit min-h-1/4 opactity-100"
+
+    // Extra Styles
+    var withDropShadowBorder = "border-2 rounded-xl drop-shadow-xl"
+    var transitionStyles = "transition-all ease-in-out delay-100 duration-250"
+
+    var withBorder = "border-2 border-solid border-red-200"
+
+    var overlayWrapper =
+        "fixed z-50 h-fit min-h-3/4 w-full max-w-xl m-auto inset-x-0 inset-y-0 p-4 rounded-sm overflow-y-scroll bg-white"
+    var overlayDialog = "flex items-center justify-center h-full"
+
+    // Modal Styles Selector
+    const modalVisibility = `${isOpen ? visible : hidden}`
+
+    if (isOpen) {
+        return (
+            <div
+                className={`${modalVisibility} ${overlayWrapper} ${withDropShadowBorder}`}
+            >
+                <Button
+                    style="none"
+                    extraStyle="ml-4"
+                    buttonText="X"
+                    handleClick={() => {
+                        setOpen && setOpen(false)
+                    }}
+                />
+                <div className={`${overlayDialog} ${transitionStyles}`}>
+                    {children}
+                </div>
+            </div>
+        )
+    }
 }
 export default Modal

--- a/context/GridContext.tsx
+++ b/context/GridContext.tsx
@@ -32,7 +32,6 @@ export default function ContextProvider({
     )
 
     /** Editor Menu State */
-    const [modalIsOpen, setModalOpen] = useState(false)
     const [menuControlsOpen, setMenuOpen] = useState(true)
 
     /** Grid State */
@@ -121,8 +120,6 @@ export default function ContextProvider({
 
     /** Export Stuff */
     const ctx: GridContextType = {
-        modalIsOpen,
-        setModalOpen,
         menuControlsOpen,
         setMenuOpen,
         mouseIsDown,

--- a/cypress/e2e/signed_out_spec.cy.ts
+++ b/cypress/e2e/signed_out_spec.cy.ts
@@ -38,20 +38,16 @@ describe("Landing Page", () => {
 // =============================================
 //              Chart Editor
 // =============================================
-describe.only("Chart Editor", () => {
+describe("Chart Editor", () => {
     beforeEach(() => {
         cy.visit("/editor", { failOnStatusCode: false })
-        cy.get("button:contains('Edit ✎')").click()
     })
 
-    describe("Layout", () => {
+    describe("layout", () => {
         it("displays the editor menu bar", function () {
             // the editor should render a controls menu
-            cy.get("button:contains('Reset Color')")
-
-            // Clicking 'X' collapses the menu bar
-            cy.get("button:contains('X')").click()
-            cy.get("button:contains('Reset Color')").should("not.exist")
+            cy.get("button:contains('Color')").click()
+            // cy.get("button:contains('Reset Color')").should("be.visible")
         })
 
         // it("displays the default grid", () => {})
@@ -59,20 +55,39 @@ describe.only("Chart Editor", () => {
         // it("does not display Recent Charts carousel", () => {})
     })
 
-    // =============================================
-    // Editor Functionality
-    // =============================================
-    // describe("Editor Grid Functionality", () => {
-    //     // -   Pixel fill modes (paint/symbol/erase) operate as expected
-    //     // -   Drag to fill operates as expected
-    //     // -   Grid size exceeds max errors display correctly
-    //     // -   Increasing/decreasing grid dimensions modified grid component as expected
-    //     // -   Download image works and saves the current chart state
-    // })
-
     describe("Chart Details", () => {
         it("does not render a chart from the database", () => {
+            cy.get("button:contains('Save')").click()
             cy.get("div").contains("Create an Account to Name & Save Your Grid")
+        })
+    })
+
+    // // =============================================
+    // // Editor Functionality
+    // // =============================================
+    describe("Editor Menu", () => {
+        describe("Color Wheel", () => {
+            it("user can set custom fill color", function () {
+                cy.get("button:contains('Color')").click()
+                cy.get("button:contains('Reset Color')").click()
+
+                // Clicking 'X' collapses the menu bar
+                // cy.get("button:contains('X')").should("exist").click()
+                cy.get("button:contains('Reset Color')").should("not.exist")
+            })
+        })
+        // -   Pixel fill modes (paint/symbol/erase) operate as expected
+        // -   Drag to fill operates as expected
+        // -   Grid size exceeds max errors display correctly
+        // -   Increasing/decreasing grid dimensions modified grid component as expected
+        // -   Download image works and saves the current chart state
+
+        describe("CTAs", () => {
+            it("New, Save, and Delete buttons should exist", function () {
+                cy.get("button:contains('New')").should("be.visible")
+                cy.get("button:contains('Delete')").should("be.visible")
+                cy.get("button:contains('Save')").should("be.visible")
+            })
         })
     })
 })

--- a/data/links.ts
+++ b/data/links.ts
@@ -2,8 +2,9 @@ const links = {
     headerNavLinks: [
         { name: "/", href: "/", title: "Home" },
         { name: "/editor", href: "/editor", title: "New Chart" },
-        { name: "/faq", href: "/faq", title: "FAQ" },
-        { name: "/contact", href: "/contact", title: "Contact" },
+        { name: "/dashboard", href: "/dashboard", title: "Dashboard" },
+        // { name: "/faq", href: "/faq", title: "FAQ" },
+        // { name: "/contact", href: "/contact", title: "Contact" },
     ],
     mainComponentLinks: [
         { name: "View the Editor", href: "/editor", title: "Get Started" },

--- a/lib/globals.ts
+++ b/lib/globals.ts
@@ -1,3 +1,7 @@
 // Server Actions and Grid Context use these
 export const DEFAULTGRIDWIDTH = 35
 export const DEFAULTGRIDHEIGHT = 25
+
+// SVG Image Components
+export const SVG_SYMBOL_WIDTH = 25
+export const SVG_SYMBOL_HEIGHT = 25

--- a/types/context.ts
+++ b/types/context.ts
@@ -2,8 +2,6 @@ import { SetStateAction } from "react"
 import { Chart } from "./chart"
 
 export type GridContextType = {
-    modalIsOpen: boolean
-    setModalOpen: React.Dispatch<SetStateAction<boolean>>
     menuControlsOpen: boolean
     setMenuOpen: React.Dispatch<SetStateAction<boolean>>
     mouseIsDown: boolean
@@ -20,4 +18,9 @@ export type GridContextType = {
     setChart: React.Dispatch<SetStateAction<Chart>>
     chartFromDatabase: Chart | null
     setDbChart: React.Dispatch<SetStateAction<Chart | null>>
+}
+
+export type ContextType = {
+    modalIsOpen: boolean
+    setModalOpen: React.Dispatch<SetStateAction<boolean>>
 }

--- a/types/context.ts
+++ b/types/context.ts
@@ -19,8 +19,3 @@ export type GridContextType = {
     chartFromDatabase: Chart | null
     setDbChart: React.Dispatch<SetStateAction<Chart | null>>
 }
-
-export type ContextType = {
-    modalIsOpen: boolean
-    setModalOpen: React.Dispatch<SetStateAction<boolean>>
-}


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
|  | Bug Fix |
| | New Feature  |
|✔️| Refactor  |
| | Update Deps  |
| | Documentation  |

### Description
---
## **⚙️ Refactor Changes**
### Modal States
- Remove modal open/setOpen states from Grid Context and from types/context.ts type definition.
- Removed modal open/setOpen states from Button component props

### Modal Overlay (Styles)
- Tweak modal styles and remove saved form modal from EditorForm for the time being. Add it back to UI and style TODO
- Move Delete Chart button from `ChartDetail` to `EditorMenu`, refactored nav buttons out to an array of values and then map over them to render instead of duplicating button components for each link. 
    
### Miscellaneous Changes 
- Updated e2e test to check for new menu buttons. Added modal open prop to the ColorWheel so that clicking 'reset color' will close the modal by default   
- Moved the Color Wheel component from Save Form to it's own Editor Menu button.
- Replace Contact link from Nav with Dashboard
- Add sizes for symbol SVGs to global constants
- Refactor Chart Symbols into their own list component

### To-Dos
---
- [ ] Add paint mode type implementation (erase, paste, normal fill, etc.) 