### PR TITLE
Refactor Editor Menu

### DIFF
--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -29,7 +29,7 @@ async function Page() {
             <h1 className="font-semibold text-lg mb-8">
                 Check out our Contributors
             </h1>
-            <ContributorsList contributors={contributors} />
+            <ContributorsList contributorsList={contributors} />
         </div>
     )
 }

--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -1,0 +1,37 @@
+import ContributorsList from "@/components/ContributorsList"
+import Image from "next/image"
+
+async function fetchData(username: string) {
+    return await fetch(`https://api.github.com/users/${username}`)
+        .then((res) => res.json())
+        .then((res) => {
+            return res.avatar_url
+        })
+}
+
+const contributors = [
+    {
+        username: "marnen",
+        avatar_url: "",
+        github: `https://github.com/marnen`,
+        repository: `https://github.com/marnen/knitting_symbols`,
+        contribution: "Japanese Knit Symbol Images",
+    },
+]
+
+async function Page() {
+    await contributors.forEach(async (contributor) => {
+        contributor.avatar_url = await fetchData(contributor.username)
+    })
+
+    return (
+        <div className="ml-24 my-8">
+            <h1 className="font-semibold text-lg mb-8">
+                Check out our Contributors
+            </h1>
+            <ContributorsList contributors={contributors} />
+        </div>
+    )
+}
+
+export default Page

--- a/app/symbols/page.tsx
+++ b/app/symbols/page.tsx
@@ -1,4 +1,4 @@
-import ChartSymbolsList from "@/components/ChartSymbols"
+import ChartSymbolsList from "@/components/ChartSymbolsList"
 
 function Page() {
     return (

--- a/components/AdvancedOptionsMenu.tsx
+++ b/components/AdvancedOptionsMenu.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import { useGridContext } from "@/context/GridContext"
+import { withBorder } from "@/data/styles"
+import { useEffect, useState } from "react"
+import Button from "./Button"
+
+const AdvancedOptionsMenu = () => {
+    const {
+        advancedEditorOptionsOpen,
+        setAdvancedOptionsOpen,
+        pixelSizeInPixels,
+        setPixelSize,
+        chart,
+        setChart,
+        maxGridWidth,
+    } = useGridContext()
+    const [sliderValue, setSliderValue] = useState(pixelSizeInPixels)
+
+    function handleSliderChange(e: React.ChangeEvent) {
+        const target = e.target as HTMLInputElement
+        setSliderValue(target.valueAsNumber)
+    }
+
+    useEffect(() => {
+        sliderValue && setPixelSize(sliderValue)
+    }, [setPixelSize, sliderValue])
+
+    function handleChartFormChange(e: React.FormEvent) {
+        const target = e.target as HTMLInputElement
+
+        switch (target.name) {
+            case "gridHeight":
+                setChart((prevState) => ({
+                    ...prevState,
+                    gridHeight: target.valueAsNumber,
+                    pixels: JSON.stringify(
+                        new Array(chart.gridWidth || 0).fill(
+                            new Array(
+                                (target && target.valueAsNumber) ||
+                                    (chart && chart.gridHeight) ||
+                                    0
+                            ).fill(null)
+                        )
+                    ),
+                }))
+                break
+            case "gridWidth":
+                if (target.valueAsNumber > maxGridWidth) {
+                    alert(
+                        "Sorry, your chart is too wide! Try setting a smaller width."
+                    )
+                } else {
+                    setChart((prevState) => ({
+                        ...prevState,
+                        gridWidth: target.valueAsNumber,
+                        pixels: JSON.stringify(
+                            new Array(
+                                (target && target.valueAsNumber) ||
+                                    (chart && chart.gridWidth) ||
+                                    0
+                            ).fill(
+                                new Array(
+                                    (chart && chart.gridHeight) || 0
+                                ).fill(null)
+                            )
+                        ),
+                    }))
+                }
+                break
+            default:
+                console.log(
+                    "there was a problem with the advanced options menu handleChange util"
+                )
+                break
+        }
+    }
+
+    if (advancedEditorOptionsOpen) {
+        return (
+            <div className="flex flex-col items-left m-4 border-2 border-gray-200 rounded-md max-w-fit mx-auto px-8 pb-8 pt-4">
+                <Button
+                    style="customWithDefaults"
+                    extraStyle="ml-0 mt-0 mr-4 mb-4 border-none px-0"
+                    buttonText="X"
+                    handleClick={() => {
+                        setAdvancedOptionsOpen && setAdvancedOptionsOpen(false)
+                    }}
+                />
+                <h3 className="font-semibold">Advanced Options</h3>
+
+                <div className={`inline-flex items-center my-2 w-fit pr-4`}>
+                    <span className="inline-block min-w-fit">
+                        <label
+                            htmlFor="pixel-size-range"
+                            className="mb-2 text-sm font-medium text-gray-900 dark:text-white min-w-fit mr-2"
+                        >
+                            Pixel Size
+                        </label>
+                    </span>
+                    <input
+                        id="pixel-size-range"
+                        type="range"
+                        min={16}
+                        max={50}
+                        value={sliderValue}
+                        className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
+                        onChange={handleSliderChange}
+                    />
+                </div>
+
+                <div>
+                    <label htmlFor="grid-height">Height</label>
+                    <input
+                        className="text-slate-600 border-2 border-black/10 rounded-md w-1/6 m-2"
+                        name="gridHeight"
+                        type="number"
+                        aria-label="gridHeight"
+                        onChange={handleChartFormChange}
+                        placeholder="Height in Pixels"
+                    />
+                    <label htmlFor="grid-width">Width</label>
+                    <input
+                        className="text-slate-600 border-2 border-black/10 rounded-md w-1/6 m-2"
+                        name="gridWidth"
+                        type="number"
+                        aria-label="gridWidth"
+                        onChange={handleChartFormChange}
+                        placeholder="Width in Pixels"
+                    />
+                </div>
+                <Button
+                    style="customWithDefaults"
+                    extraStyle="mr-4 mt-4"
+                    buttonText="Done"
+                    handleClick={() => {
+                        setAdvancedOptionsOpen && setAdvancedOptionsOpen(false)
+                    }}
+                />
+            </div>
+        )
+    }
+}
+
+export default AdvancedOptionsMenu

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -27,6 +27,7 @@ const Card = ({ p }: { p: Chart }) => {
                     Last Updated: Date & Time (TODO)
                 </div>
 
+                {/* TODO Add a modal for confirming you want to lose current editor changes before loading a chart from the database */}
                 <div onClick={handleClick} className="mt-2">
                     View &rarr;
                 </div>

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -5,11 +5,11 @@ function Carousel({
     title?: string
     children: React.ReactNode
 }) {
-    const titleText: string = title ? title : "Recent"
+    const headerText = title ? title : null
     return (
-        <div className="ml-32 my-8">
-            <h1 className="font-semibold mb-2 text-center md:text-left">
-                {titleText}
+        <div className="max-w-3/4 w-fit mx-auto">
+            <h1 className="font-semibold text-center md:text-left my-4">
+                {headerText}
             </h1>
             <div className="md:h-60 flex flex-col justify-center items-center md:flex-row md:overflow-scroll md:flex-nowrap md:justify-start">
                 {children}

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -1,3 +1,4 @@
+import AdvancedOptionsMenu from "./AdvancedOptionsMenu"
 import EditorForm from "./EditorForm"
 import Grid from "./Grid"
 import SearchBar from "./SearchBar"
@@ -10,6 +11,7 @@ const Chart = ({ userId }: { userId: string | null }) => {
 
             <Suspense fallback={<h2>Loading...</h2>}>
                 <SearchBar />
+                <AdvancedOptionsMenu />
                 <Grid />
             </Suspense>
         </div>

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -1,0 +1,18 @@
+import EditorForm from "./EditorForm"
+import Grid from "./Grid"
+import SearchBar from "./SearchBar"
+import { Suspense } from "react"
+
+const Chart = ({ userId }: { userId: string | null }) => {
+    return (
+        <div>
+            <EditorForm authorized={userId ? true : false} />
+
+            <Suspense fallback={<h2>Loading...</h2>}>
+                <SearchBar />
+                <Grid />
+            </Suspense>
+        </div>
+    )
+}
+export default Chart

--- a/components/ChartEditor.tsx
+++ b/components/ChartEditor.tsx
@@ -2,22 +2,15 @@ import { auth } from "@clerk/nextjs"
 import { Suspense } from "react"
 
 // Components
-import EditorForm from "./EditorForm"
-import Grid from "./Grid"
+import Chart from "./Chart"
 import RecentChartsList from "./RecentChartsList"
-import SearchBar from "./SearchBar"
 
 async function ChartEditor() {
     const { userId } = await auth()
 
     return (
         <>
-            <EditorForm authorized={userId ? true : false} />
-
-            <Suspense fallback={<h2>Loading...</h2>}>
-                <SearchBar />
-                <Grid />
-            </Suspense>
+            <Chart userId={userId} />
 
             <Suspense fallback={<h2>Loading...</h2>}>
                 <RecentChartsList />

--- a/components/ChartEditor.tsx
+++ b/components/ChartEditor.tsx
@@ -1,8 +1,11 @@
 import { auth } from "@clerk/nextjs"
+import { Suspense } from "react"
+
+// Components
 import EditorForm from "./EditorForm"
 import Grid from "./Grid"
 import RecentChartsList from "./RecentChartsList"
-import { Suspense } from "react"
+import SearchBar from "./SearchBar"
 
 async function ChartEditor() {
     const { userId } = await auth()
@@ -10,9 +13,12 @@ async function ChartEditor() {
     return (
         <>
             <EditorForm authorized={userId ? true : false} />
+
             <Suspense fallback={<h2>Loading...</h2>}>
+                <SearchBar />
                 <Grid />
             </Suspense>
+
             <Suspense fallback={<h2>Loading...</h2>}>
                 <RecentChartsList />
             </Suspense>

--- a/components/ContributorsList.tsx
+++ b/components/ContributorsList.tsx
@@ -1,32 +1,38 @@
 "use client"
 import { transitionStyles } from "@/data/styles"
 import Image from "next/image"
-import { Suspense } from "react"
+import { Suspense, useEffect, useState } from "react"
 
 type ContributorsType = {
     username: string
     github: string
-    repository: string
+    repository?: string
     avatar_url: string
     contribution: string
 }
 
 function ContributorsList({
-    contributors,
+    contributorsList,
 }: {
-    contributors: ContributorsType[]
+    contributorsList: ContributorsType[]
 }) {
+    const [contributors, setCB] = useState<ContributorsType[]>([])
+
+    useEffect(() => {
+        contributorsList && setCB(contributorsList)
+    }, [contributorsList])
+
     return (
         <>
             <Suspense fallback={<h2>Loading...</h2>}>
-                <div className="flex justify-center items-center w-fit">
+                <div className="flex flex-col">
                     {contributors &&
                         contributors.map((cb, index) => (
                             <a
                                 key={index}
                                 href={cb.repository ? cb.repository : cb.github}
                             >
-                                <span className="inline-flex items-center">
+                                <span className="inline-flex items-center my-2">
                                     <Image
                                         className={`mx-4 rounded-full hover:scale-105 ${transitionStyles}`}
                                         src={cb.avatar_url && cb.avatar_url}
@@ -34,10 +40,11 @@ function ContributorsList({
                                         height="100"
                                         alt="Profile pic"
                                     />{" "}
-                                    |{" "}
-                                    <span className="ml-4">
-                                        {cb.contribution}
-                                    </span>
+                                    {cb.contribution && (
+                                        <span className="ml-4">
+                                            | {cb.contribution}
+                                        </span>
+                                    )}
                                 </span>
                             </a>
                         ))}

--- a/components/ContributorsList.tsx
+++ b/components/ContributorsList.tsx
@@ -1,0 +1,50 @@
+"use client"
+import { transitionStyles } from "@/data/styles"
+import Image from "next/image"
+import { Suspense } from "react"
+
+type ContributorsType = {
+    username: string
+    github: string
+    repository: string
+    avatar_url: string
+    contribution: string
+}
+
+function ContributorsList({
+    contributors,
+}: {
+    contributors: ContributorsType[]
+}) {
+    return (
+        <>
+            <Suspense fallback={<h2>Loading...</h2>}>
+                <div className="flex justify-center items-center w-fit">
+                    {contributors &&
+                        contributors.map((cb, index) => (
+                            <a
+                                key={index}
+                                href={cb.repository ? cb.repository : cb.github}
+                            >
+                                <span className="inline-flex items-center">
+                                    <Image
+                                        className={`mx-4 rounded-full hover:scale-105 ${transitionStyles}`}
+                                        src={cb.avatar_url && cb.avatar_url}
+                                        width="100"
+                                        height="100"
+                                        alt="Profile pic"
+                                    />{" "}
+                                    |{" "}
+                                    <span className="ml-4">
+                                        {cb.contribution}
+                                    </span>
+                                </span>
+                            </a>
+                        ))}
+                </div>
+            </Suspense>
+        </>
+    )
+}
+
+export default ContributorsList

--- a/components/EditorForm.tsx
+++ b/components/EditorForm.tsx
@@ -167,31 +167,6 @@ function EditorForm({ authorized }: { authorized: boolean }) {
                                         value={chart.title ? chart.title : ""}
                                         onChange={handleChartFormChange}
                                     />
-
-                                    <div>
-                                        <label htmlFor="grid-height">
-                                            Height
-                                        </label>
-                                        <input
-                                            className="text-slate-600 border-2 border-black/10 rounded-md w-1/6 m-2"
-                                            name="gridHeight"
-                                            type="number"
-                                            aria-label="gridHeight"
-                                            onChange={handleChartFormChange}
-                                            placeholder="Height in Pixels"
-                                        />
-                                        <label htmlFor="grid-width">
-                                            Width
-                                        </label>
-                                        <input
-                                            className="text-slate-600 border-2 border-black/10 rounded-md w-1/6 m-2"
-                                            name="gridWidth"
-                                            type="number"
-                                            aria-label="gridWidth"
-                                            onChange={handleChartFormChange}
-                                            placeholder="Width in Pixels"
-                                        />
-                                    </div>
                                 </div>
                             </>
 

--- a/components/EditorMenu.tsx
+++ b/components/EditorMenu.tsx
@@ -20,6 +20,8 @@ function EditorMenu({
 }) {
     const {
         chart,
+        advancedEditorOptionsOpen,
+        setAdvancedOptionsOpen,
         menuControlsOpen,
         setMenuOpen,
         defaultFillColor,
@@ -66,7 +68,7 @@ function EditorMenu({
         {
             type: "select",
             value: "Fill Mode",
-            options: ["Fill Mode", "Paint", "Erase", "Symbol", "Paste"],
+            options: ["Fill Mode", "Paint", "Erase", "Symbol" /* "Paste"*/],
             handleChange: (e: React.ChangeEvent) => {
                 let target = e.target as HTMLSelectElement
                 setFillMode(target.value)
@@ -74,21 +76,36 @@ function EditorMenu({
             style: "none",
         },
         {
+            type: "select",
+            value: "Edit",
+            options: ["Edit", "Remove Fill", "Reset Size"],
+            handleChange: (e: React.ChangeEvent) => {
+                let target = e.target as HTMLSelectElement
+                switch (target.value) {
+                    case "Remove Fill":
+                        handleRemoveGridFill()
+                        break
+                    case "Reset Size":
+                        renderEmptyGrid() // should this preserve the current fill? add a warning about data loss if not
+                        break
+                    default:
+                        console.log("targval", target.value)
+                }
+            },
+            style: "none",
+        },
+        {
+            type: "button",
+            value: "Advanced",
+            handleClick: () =>
+                setAdvancedOptionsOpen &&
+                setAdvancedOptionsOpen(!advancedEditorOptionsOpen),
+            style: "none",
+        },
+        {
             type: "button",
             value: "Color",
             handleClick: () => setColorWheelOpen(!colorwheelOpen),
-            style: "none",
-        },
-        {
-            type: "button",
-            value: "Remove Fill",
-            handleClick: handleRemoveGridFill,
-            style: "none",
-        },
-        {
-            type: "button",
-            value: "Reset Size",
-            handleClick: renderEmptyGrid,
             style: "none",
         },
     ]
@@ -145,8 +162,7 @@ function EditorMenu({
             } else if (link.type === "select") {
                 return (
                     <select
-                        className="border-none rounded-md bg-transparent"
-                        name="mode"
+                        className="rounded-md bg-transparent mx-1 text-center"
                         key={index}
                         onChange={link.handleChange}
                     >
@@ -178,7 +194,7 @@ function EditorMenu({
                             buttonText="Yes"
                             handleClick={async (e) => {
                                 setOpen(false)
-                                await handleResetGridToDefault(e)
+                                await handleResetGridToDefault()
                                 await deletePixelGridServerAction(chart.id)
                             }}
                         />

--- a/components/EditorMenu.tsx
+++ b/components/EditorMenu.tsx
@@ -21,19 +21,21 @@ function EditorMenu({
         defaultFillColor,
         renderEmptyGrid,
         setPixelFillColor,
+        setFillMode,
     } = useGridContext()
 
     const [open, setOpen] = useState(false)
     const { setPixelIsFilled, removePixelFill } = usePixelIsFilled()
     const [colorwheelOpen, setColorWheelOpen] = useState(false)
 
-    var buttons = [
+    var menuLinks = [
         {
             type: "select",
             value: "Mode",
-            options: ["Mode", "Fill", "Erase", "Paste"],
-            handleClick: () => {
-                // setPMOpen(!paintModeOpen)
+            options: ["Mode", "Fill", "Erase", "Symbol", "Paste"],
+            handleChange: (e: React.ChangeEvent) => {
+                let target = e.target as HTMLSelectElement
+                setFillMode(target.value)
             },
             style: "none",
         },
@@ -109,8 +111,8 @@ function EditorMenu({
     }
 
     const links =
-        buttons &&
-        buttons.map((link, index) => {
+        menuLinks &&
+        menuLinks.map((link, index) => {
             if (link.type === "button") {
                 return (
                     <Button
@@ -122,7 +124,11 @@ function EditorMenu({
                 )
             } else if (link.type === "select") {
                 return (
-                    <select name="mode" key={index}>
+                    <select
+                        name="mode"
+                        key={index}
+                        onChange={link.handleChange}
+                    >
                         {link.options &&
                             link.options.map((text, index) => {
                                 return (

--- a/components/EditorMenu.tsx
+++ b/components/EditorMenu.tsx
@@ -31,8 +31,8 @@ function EditorMenu({
     var menuLinks = [
         {
             type: "select",
-            value: "Mode",
-            options: ["Mode", "Fill", "Erase", "Symbol", "Paste"],
+            value: "Fill Mode",
+            options: ["Fill Mode", "Paint", "Erase", "Symbol", "Paste"],
             handleChange: (e: React.ChangeEvent) => {
                 let target = e.target as HTMLSelectElement
                 setFillMode(target.value)
@@ -125,6 +125,7 @@ function EditorMenu({
             } else if (link.type === "select") {
                 return (
                     <select
+                        className="border-none rounded-md bg-transparent"
                         name="mode"
                         key={index}
                         onChange={link.handleChange}
@@ -197,15 +198,14 @@ function EditorMenu({
                         </Modal>
                         {links && links}
                     </div>
+
                     <Button
                         style="none"
                         buttonText={`${menuControlsOpen ? "X" : "Menu +"}`}
                         handleClick={() => {
-                            if (modalIsOpen) {
-                                setModalOpen(false)
-                            } else {
-                                setMenuOpen(!menuControlsOpen)
-                            }
+                            modalIsOpen
+                                ? setModalOpen(false)
+                                : setMenuOpen(!menuControlsOpen)
                         }}
                     />
                 </div>

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -25,6 +25,7 @@ function Grid() {
 
         if (target) {
             target.addEventListener("mousedown", function () {
+                setFillOnDrag(true)
                 setMouseDownState(true)
             })
 

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useGridContext } from "@/context/GridContext"
-import { useEffect, useRef } from "react"
+import { Suspense, useEffect, useRef } from "react"
 import html2canvas from "html2canvas"
 import Button from "./Button"
 
@@ -54,36 +54,38 @@ function Grid() {
         }
     }
 
-    return (
-        <div className="flex flex-col w-fit m-auto" onClick={handleClick}>
-            <div
-                className="flex justify-center"
-                id="grid"
-                aria-label="grid"
-                data-testid="grid"
-            >
+    if (grid.length) {
+        return (
+            <div className="flex flex-col w-fit m-auto" onClick={handleClick}>
                 <div
-                    style={{
-                        gridTemplateColumns: `repeat(${grid.length}, minmax(0, 1fr))`,
-                    }}
-                    className="border-solid border-2 grid rounded-lg"
-                    ref={ref}
+                    className="flex justify-center"
+                    id="grid"
+                    aria-label="grid"
+                    data-testid="grid"
                 >
-                    {grid.length && grid}
+                    <div
+                        style={{
+                            gridTemplateColumns: `repeat(${grid.length}, minmax(0, 1fr))`,
+                        }}
+                        className="border-solid border-2 grid rounded-lg"
+                        ref={ref}
+                    >
+                        {grid && grid}
+                    </div>
+                </div>
+                <div className="h-0"></div>
+
+                <div className="flex justify-end my-4">
+                    <Button
+                        style="custom"
+                        extraStyle="p-2 mt-4"
+                        handleClick={handleDownloadImage}
+                        buttonText="Download As Img"
+                    />
                 </div>
             </div>
-            <div className="h-0"></div>
-
-            <div className="flex justify-end">
-                <Button
-                    style="custom"
-                    extraStyle="p-2 mt-4"
-                    handleClick={handleDownloadImage}
-                    buttonText="Download As Img"
-                />
-            </div>
-        </div>
-    )
+        )
+    }
 }
 
 export default Grid

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -13,8 +13,6 @@ function Grid() {
         setFillOnDrag,
     } = useGridContext()
 
-    const ref = useRef<HTMLDivElement>(null)
-
     // Fetch from db and render a user-selected grid
     useEffect(() => {
         chartFromDatabase && setChart(chartFromDatabase)
@@ -36,61 +34,28 @@ function Grid() {
         }
     }
 
-    const handleDownloadImage = async () => {
-        const element = ref.current as HTMLDivElement
-        const canvas = await html2canvas(element)
-
-        const data = canvas.toDataURL("image/jpg")
-        const link = document.createElement("a")
-
-        if (typeof link.download === "string") {
-            link.href = data
-            link.download = "image.jpg"
-
-            document.body.appendChild(link)
-            link.click()
-            document.body.removeChild(link)
-        } else {
-            window.open(data)
-        }
-    }
-
     if (grid.length) {
         return (
             <div
+                id="grid"
                 onMouseLeave={() => {
                     setFillOnDrag(false)
                     setMouseDownState(false)
                 }}
-                className="flex flex-col w-fit m-auto"
+                className="flex flex-col w-fit m-auto p-16"
                 onClick={handleClick}
             >
-                <div
-                    className="flex justify-center"
-                    id="grid"
-                    aria-label="grid"
-                    data-testid="grid"
-                >
+                <div className="flex justify-center" aria-label="grid">
                     <div
                         style={{
                             gridTemplateColumns: `repeat(${grid.length}, minmax(0, 1fr))`,
                         }}
                         className="border-solid border-2 grid rounded-lg"
-                        ref={ref}
                     >
                         {grid && grid}
                     </div>
                 </div>
                 <div className="h-0"></div>
-
-                <div className="flex justify-end my-4">
-                    <Button
-                        style="custom"
-                        extraStyle="p-2 mt-4"
-                        handleClick={handleDownloadImage}
-                        buttonText="Download As Img"
-                    />
-                </div>
             </div>
         )
     }

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -56,7 +56,14 @@ function Grid() {
 
     if (grid.length) {
         return (
-            <div className="flex flex-col w-fit m-auto" onClick={handleClick}>
+            <div
+                onMouseLeave={() => {
+                    setFillOnDrag(false)
+                    setMouseDownState(false)
+                }}
+                className="flex flex-col w-fit m-auto"
+                onClick={handleClick}
+            >
                 <div
                     className="flex justify-center"
                     id="grid"

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -42,7 +42,7 @@ function Grid() {
                     setFillOnDrag(false)
                     setMouseDownState(false)
                 }}
-                className="flex flex-col w-fit m-auto p-16"
+                className="flex flex-col w-fit m-auto pt-8 pb-16"
                 onClick={handleClick}
             >
                 <div className="flex justify-center" aria-label="grid">

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { SetStateAction } from "react"
 import Button from "./Button"
+import { transitionStyles, withDropShadowBorder } from "@/data/styles"
 
 const Modal = ({
     isOpen,
@@ -14,12 +15,6 @@ const Modal = ({
     // Default Styles
     var hidden = "opacity-0 h-0"
     var visible = "h-fit min-h-1/4 opactity-100"
-
-    // Extra Styles
-    var withDropShadowBorder = "border-2 rounded-xl drop-shadow-xl"
-    var transitionStyles = "transition-all ease-in-out delay-100 duration-250"
-
-    var withBorder = "border-2 border-solid border-red-200"
 
     var overlayWrapper =
         "fixed z-50 h-fit min-h-3/4 w-full max-w-xl m-auto inset-x-0 inset-y-0 p-4 rounded-sm overflow-y-scroll bg-white"

--- a/components/Pixel.tsx
+++ b/components/Pixel.tsx
@@ -19,19 +19,47 @@ function GridPixel({
         mouseIsDown,
         fillWhenDragged,
         setFillOnDrag,
+        editorFillMode,
     } = useGridContext()
 
-    function handleClick(e: React.MouseEvent) {
+    function handleGridPixelClick(e: React.MouseEvent) {
         const target = e.target as HTMLDivElement
 
+        // Implementation TODO:
+        // Hold down cmd + click/drag to erase when in paint mode, to paint when in erase mode,
+        // and to select a block of pixels when in copy/paste mode
         if (target) {
-            if (!pixelIsFilled) {
-                setPixelIsFilled(true)
-                fillGridPixel(target, JSON.parse(chart.pixels), position)
-                setFillOnDrag(true)
-            } else if (pixelIsFilled) {
-                setPixelIsFilled(false)
-                removePixelFill(target, JSON.parse(chart.pixels), position)
+            try {
+                switch (editorFillMode) {
+                    case "Paint":
+                        setFillOnDrag(true)
+                        setPixelIsFilled(true)
+                        fillGridPixel(
+                            target,
+                            JSON.parse(chart.pixels),
+                            position
+                        )
+                        break
+                    case "Erase":
+                        console.log("erase fill mode")
+                        setPixelIsFilled(false)
+                        removePixelFill(
+                            target,
+                            JSON.parse(chart.pixels),
+                            position
+                        )
+                        break
+                    case "Symbol":
+                        console.log("symbol fill mode")
+                        // IMPLEMENTATION TODO
+                        break
+                    case "Paste":
+                        console.log("paste fill mode")
+                        // IMPLEMENTATION TODO
+                        break
+                }
+            } catch (e) {
+                console.log("problem filling grid pixel")
             }
         }
     }
@@ -53,13 +81,13 @@ function GridPixel({
     const fill = !filled ? undefined : fillColor ? fillColor : pixelFillColor
     return (
         <div
-            onMouseDown={handleClick}
+            onMouseDown={handleGridPixelClick}
             onMouseEnter={handleClickandDrag}
             style={{
                 backgroundColor: fill,
             }}
             className="grid-pixel border-solid border-y border-x w-4 h-4 p-2"
-        ></div>
+        ></div> // Custom pixel size TODO
     )
 }
 

--- a/components/Pixel.tsx
+++ b/components/Pixel.tsx
@@ -21,6 +21,7 @@ function GridPixel({
         fillWhenDragged,
         setFillOnDrag,
         editorFillMode,
+        pixelSizeInPixels,
     } = useGridContext()
 
     function handleFillGridPixel(e: React.MouseEvent) {
@@ -97,9 +98,11 @@ function GridPixel({
             }}
             style={{
                 backgroundColor: fill,
+                width: `${pixelSizeInPixels}px`,
+                height: `${pixelSizeInPixels}px`,
             }}
-            className="grid-pixel border-solid border-y border-x w-4 h-4 p-2"
-        ></div> // Custom pixel size TODO
+            className={`grid-pixel border-solid border-y border-x p-2`}
+        ></div>
     )
 }
 

--- a/components/Pixel.tsx
+++ b/components/Pixel.tsx
@@ -17,12 +17,13 @@ function GridPixel({
         chart,
         pixelFillColor,
         mouseIsDown,
+        setMouseDownState,
         fillWhenDragged,
         setFillOnDrag,
         editorFillMode,
     } = useGridContext()
 
-    function handleGridPixelClick(e: React.MouseEvent) {
+    function handleFillGridPixel(e: React.MouseEvent) {
         const target = e.target as HTMLDivElement
 
         // Implementation TODO:
@@ -30,9 +31,21 @@ function GridPixel({
         // and to select a block of pixels when in copy/paste mode
         if (target) {
             try {
+                // target.addEventListener("mousedown", function () {
+                //     setFillOnDrag(true)
+                //     setMouseDownState(true)
+                // })
+
+                // target.addEventListener("mouseup", function () {
+                //     setFillOnDrag(false)
+                //     setMouseDownState(false)
+                // })
+
                 switch (editorFillMode) {
                     case "Paint":
+                        setMouseDownState(true)
                         setFillOnDrag(true)
+
                         setPixelIsFilled(true)
                         fillGridPixel(
                             target,
@@ -41,7 +54,10 @@ function GridPixel({
                         )
                         break
                     case "Erase":
-                        console.log("erase fill mode")
+                        // console.log("erase fill mode")
+                        setMouseDownState(true)
+                        setFillOnDrag(true)
+
                         setPixelIsFilled(false)
                         removePixelFill(
                             target,
@@ -68,12 +84,14 @@ function GridPixel({
         const target = e.target as HTMLDivElement
 
         if (target && mouseIsDown) {
-            if (fillWhenDragged) {
+            if (fillWhenDragged && editorFillMode === "Paint") {
                 setPixelIsFilled(true)
                 fillGridPixel(target, JSON.parse(chart.pixels), position)
-            } else {
+            } else if (fillWhenDragged && editorFillMode === "Erase") {
                 setPixelIsFilled(false)
                 removePixelFill(target, JSON.parse(chart.pixels), position)
+            } else {
+                console.log("there was a problem with drag to fill")
             }
         }
     }
@@ -81,8 +99,12 @@ function GridPixel({
     const fill = !filled ? undefined : fillColor ? fillColor : pixelFillColor
     return (
         <div
-            onMouseDown={handleGridPixelClick}
+            onMouseDown={handleFillGridPixel}
             onMouseEnter={handleClickandDrag}
+            onMouseUp={() => {
+                setFillOnDrag(false)
+                setMouseDownState(false)
+            }}
             style={{
                 backgroundColor: fill,
             }}

--- a/components/Pixel.tsx
+++ b/components/Pixel.tsx
@@ -31,16 +31,6 @@ function GridPixel({
         // and to select a block of pixels when in copy/paste mode
         if (target) {
             try {
-                // target.addEventListener("mousedown", function () {
-                //     setFillOnDrag(true)
-                //     setMouseDownState(true)
-                // })
-
-                // target.addEventListener("mouseup", function () {
-                //     setFillOnDrag(false)
-                //     setMouseDownState(false)
-                // })
-
                 switch (editorFillMode) {
                     case "Paint":
                         setMouseDownState(true)

--- a/components/RecentChartsList.tsx
+++ b/components/RecentChartsList.tsx
@@ -28,12 +28,16 @@ async function RecentChartsList() {
 
     if (chartsFromDatabase) {
         return (
-            <div className="ml-32 my-8">
-                <Carousel>
-                    {chartsFromDatabase.map((p, i) => (
-                        <Card p={p} key={i} />
-                    ))}
-                </Carousel>
+            <div className="mx-16">
+                <div className="flex justify-center items-center">
+                    <div className={`max-w-1/2 w-fit overflow-scroll`}>
+                        <Carousel title="Recently Viewed">
+                            {chartsFromDatabase.map((p, i) => (
+                                <Card p={p} key={i} />
+                            ))}
+                        </Carousel>
+                    </div>
+                </div>
             </div>
         )
     }

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,16 @@
+"use client"
+import { useGridContext } from "@/context/GridContext"
+
+// Implementation TODO
+const SearchBar = () => {
+    const { editorFillMode } = useGridContext()
+    if (editorFillMode === "Symbol") {
+        return (
+            <div className="flex justify-center m-4 border-2 border-gray-200 rounded-md max-w-fit mx-auto px-8 py-2">
+                <h3>Symbols Search Bar</h3>
+            </div>
+        )
+    }
+}
+
+export default SearchBar

--- a/components/SideBar.tsx
+++ b/components/SideBar.tsx
@@ -1,28 +1,34 @@
+import { transitionStyles } from "@/data/styles"
+
 const sideBarLinkStyles =
     "group rounded-lg border border-transparent first-letter:transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30 text-sm p-4"
 
 const SideBar = async () => {
     return (
         <div
-            className={`absolute min-w-max m-0 py-4 pl-4 pr-8 opacity-0 hover:opacity-100`}
+            className={`absolute flex items-start translate-y-[10rem] transition-all ease-in-out duration-750" -translate-x-[85%] hover:translate-x-1`}
         >
-            <a href="/editor">
-                <h2 className={sideBarLinkStyles}>Chart Editor</h2>
-            </a>
+            <div
+                className={`flex flex-col h-fit min-w-max m-0 py-4 pl-4 pr-8 bg-opacity-100 bg-slate-800 rounded-md`}
+            >
+                <a href="/editor">
+                    <h2 className={sideBarLinkStyles}>Chart Editor</h2>
+                </a>
 
-            <a href="/symbols">
-                <h2 className={sideBarLinkStyles}>Chart Symbols</h2>
-            </a>
-            <a href="/dashboard">
-                <h2 className={sideBarLinkStyles}>Dashboard </h2>
-            </a>
-            <a href="/templates">
-                <h2 className={sideBarLinkStyles}>Templates </h2>
-            </a>
+                <a href="/symbols">
+                    <h2 className={sideBarLinkStyles}>Chart Symbols</h2>
+                </a>
+                <a href="/dashboard">
+                    <h2 className={sideBarLinkStyles}>Dashboard </h2>
+                </a>
+                <a href="/templates">
+                    <h2 className={sideBarLinkStyles}>Templates </h2>
+                </a>
 
-            <a href="/community">
-                <h2 className={sideBarLinkStyles}>Community </h2>
-            </a>
+                <a href="/community">
+                    <h2 className={sideBarLinkStyles}>Community </h2>
+                </a>
+            </div>
         </div>
     )
 }

--- a/components/SideBar.tsx
+++ b/components/SideBar.tsx
@@ -3,6 +3,13 @@ import { transitionStyles } from "@/data/styles"
 const sideBarLinkStyles =
     "group rounded-lg border border-transparent first-letter:transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30 text-sm p-4"
 
+const sideBarLinks = [
+    { href: "/editor", linkText: "Chart Editor" },
+    { href: "/symbols", linkText: "Symbols" },
+    { href: "/templates", linkText: "Templates" },
+    { href: "/community", linkText: "Community" },
+]
+
 const SideBar = async () => {
     return (
         <div
@@ -11,23 +18,16 @@ const SideBar = async () => {
             <div
                 className={`flex flex-col h-fit min-w-max m-0 py-4 pl-4 pr-8 bg-opacity-100 bg-slate-800 rounded-md`}
             >
-                <a href="/editor">
-                    <h2 className={sideBarLinkStyles}>Chart Editor</h2>
-                </a>
-
-                <a href="/symbols">
-                    <h2 className={sideBarLinkStyles}>Chart Symbols</h2>
-                </a>
-                <a href="/dashboard">
-                    <h2 className={sideBarLinkStyles}>Dashboard </h2>
-                </a>
-                <a href="/templates">
-                    <h2 className={sideBarLinkStyles}>Templates </h2>
-                </a>
-
-                <a href="/community">
-                    <h2 className={sideBarLinkStyles}>Community </h2>
-                </a>
+                {sideBarLinks &&
+                    sideBarLinks.map((link, index) => (
+                        <a
+                            className={sideBarLinkStyles}
+                            key={index}
+                            href={link.href}
+                        >
+                            <h2>{link.linkText}</h2>
+                        </a>
+                    ))}
             </div>
         </div>
     )

--- a/context/GridContext.tsx
+++ b/context/GridContext.tsx
@@ -1,6 +1,10 @@
 "use client"
 import GridPixel from "@/components/Pixel"
-import { DEFAULTGRIDHEIGHT, DEFAULTGRIDWIDTH } from "@/lib/globals"
+import {
+    DEFAULTGRIDHEIGHT,
+    DEFAULTGRIDWIDTH,
+    DEFAULT_PIXEL_SIZE_PX,
+} from "@/lib/globals"
 import { GridContextType } from "@/types/context"
 import { Chart } from "@/types/chart"
 import {
@@ -35,12 +39,16 @@ export default function ContextProvider({
     const [menuControlsOpen, setMenuOpen] = useState(true)
     const [editorFillMode, setFillMode] = useState("Paint")
 
+    /** Advanced Editor Options */
+    const [advancedEditorOptionsOpen, setAdvancedOptionsOpen] = useState(false)
+
     /** Grid State */
     const [mouseIsDown, setMouseDownState] = useState(false)
     const [fillWhenDragged, setFillOnDrag] = useState(false)
     const [grid, setGrid] = useState<React.ReactNode[]>([])
 
     /** Pixel State */
+    const [pixelSizeInPixels, setPixelSize] = useState(DEFAULT_PIXEL_SIZE_PX)
     const [pixelFillColor, setPixelFillColor] = useState(defaultFillColor)
 
     /** Grid Currently Rendered in the Editor (from database) */
@@ -121,6 +129,10 @@ export default function ContextProvider({
 
     /** Export Stuff */
     const ctx: GridContextType = {
+        advancedEditorOptionsOpen,
+        setAdvancedOptionsOpen,
+        pixelSizeInPixels,
+        setPixelSize,
         editorFillMode,
         setFillMode,
         menuControlsOpen,

--- a/context/GridContext.tsx
+++ b/context/GridContext.tsx
@@ -33,6 +33,7 @@ export default function ContextProvider({
 
     /** Editor Menu State */
     const [menuControlsOpen, setMenuOpen] = useState(true)
+    const [editorFillMode, setFillMode] = useState("Fill")
 
     /** Grid State */
     const [mouseIsDown, setMouseDownState] = useState(false)
@@ -120,6 +121,8 @@ export default function ContextProvider({
 
     /** Export Stuff */
     const ctx: GridContextType = {
+        editorFillMode,
+        setFillMode,
         menuControlsOpen,
         setMenuOpen,
         mouseIsDown,

--- a/context/GridContext.tsx
+++ b/context/GridContext.tsx
@@ -33,7 +33,7 @@ export default function ContextProvider({
 
     /** Editor Menu State */
     const [menuControlsOpen, setMenuOpen] = useState(true)
-    const [editorFillMode, setFillMode] = useState("Fill")
+    const [editorFillMode, setFillMode] = useState("Paint")
 
     /** Grid State */
     const [mouseIsDown, setMouseDownState] = useState(false)

--- a/data/styles.ts
+++ b/data/styles.ts
@@ -1,0 +1,5 @@
+// Global Style Classes
+export const withDropShadowBorder = "border-2 rounded-xl drop-shadow-xl"
+export const transitionStyles =
+    "transition-all ease-in-out delay-100 duration-250"
+export const withBorder = "border-2 border-solid border-red-200"

--- a/lib/globals.ts
+++ b/lib/globals.ts
@@ -2,6 +2,9 @@
 export const DEFAULTGRIDWIDTH = 35
 export const DEFAULTGRIDHEIGHT = 25
 
+// Pixel Sizes
+export const DEFAULT_PIXEL_SIZE_PX = 16
+
 // SVG Image Components
 export const SVG_SYMBOL_WIDTH = 25
 export const SVG_SYMBOL_HEIGHT = 25

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,6 +10,7 @@ export default authMiddleware({
         "/symbols",
         "/editor",
         "/faq",
+        "/contributors",
         "/templates",
     ],
 })

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,16 @@ const nextConfig = {
     experimental: {
         serverActions: true,
     },
+    images: {
+        remotePatterns: [
+            {
+                protocol: "https",
+                hostname: "avatars.githubusercontent.com",
+                port: "",
+                pathname: "/**",
+            },
+        ],
+    },
 }
 
 module.exports = nextConfig

--- a/types/context.ts
+++ b/types/context.ts
@@ -2,6 +2,8 @@ import { SetStateAction } from "react"
 import { Chart } from "./chart"
 
 export type GridContextType = {
+    editorFillMode: string
+    setFillMode: React.Dispatch<SetStateAction<string>>
     menuControlsOpen: boolean
     setMenuOpen: React.Dispatch<SetStateAction<boolean>>
     mouseIsDown: boolean

--- a/types/context.ts
+++ b/types/context.ts
@@ -9,6 +9,8 @@ export type GridContextType = {
     menuControlsOpen: boolean
     setMenuOpen: React.Dispatch<SetStateAction<boolean>>
     mouseIsDown: boolean
+    pixelSizeInPixels: number
+    setPixelSize: React.Dispatch<SetStateAction<number>>
     setFillOnDrag: React.Dispatch<SetStateAction<boolean>>
     fillWhenDragged: boolean
     setMouseDownState: React.Dispatch<SetStateAction<boolean>>

--- a/types/context.ts
+++ b/types/context.ts
@@ -2,6 +2,8 @@ import { SetStateAction } from "react"
 import { Chart } from "./chart"
 
 export type GridContextType = {
+    advancedEditorOptionsOpen: boolean
+    setAdvancedOptionsOpen: React.Dispatch<SetStateAction<boolean>>
     editorFillMode: string
     setFillMode: React.Dispatch<SetStateAction<string>>
     menuControlsOpen: boolean


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
|✔️| Bug Fix |
|✔️| New Feature  |
|✔️| Refactor  |
| | Update Deps  |
| | Documentation  |

### Description
_This should not be a single PR, I won't split this one but aim to make smaller PRs with only one type in the future._ 

---
## **⚙️ Refactor Changes**
### Editor Menu Bar
- Grouped related functionality (save, delete, new chart, and export PNG in one group, remove/reset grid in another, etc.) under drop-down menus to save space in the menu bar.
- Add **Fill Mode** to the editor menu bar, state/setState for the new fill modes, and added state/setState to the Grid Context type. User can now choose to 'Paint' pixels, 'Erase', add a 'Symbol', and 'Copy/Paste' a range of pixels. The default is set to "Paint" and only paint/erase have been implemented so far.  
- Moved Chart components from `ChartEditor` to their own `Chart` component (editor form, search bar, and the grid)
-  Style select element to match other editor menu buttons

### AdvancedOptions Menu
- Added an **Advanced Options** menu that can be toggled open/closed from the Editor Menu. (May convert to a checkbox instead of a button in the future but works for now. This menu allows adjusting the grid size and pixel size.)
- Moved the grid height/width controls from the **Save Chart** menu to the **Advanced Options** menu.
- Added visibility state management to the Grid Context for toggling the Advanced Options Menu open/closed. Updated the context types file to reflect additional state variables.

### Sidebar
- Fix Sidebar styles so it is opaque and hover reveals it from the left-side of the app
- Extracted global Tailwind style classes to their own file and removed hardcoded values from `Modal.tsx`

## New Feature Changes
### Contributors Page
- Added a component and route for rendering contributors (links to their Github profile). Updated next config image settings and made the new contributors route public so a guest user can view it.
- Add state/setState for the list of contributors 

### Enlarge Grid Pixels / Zoom In and Out
  - Zooming in currently enlarges individual pixel size for easy visibility and editing for all charts— this means that if you create a new chart and enlarge the pixel size via the editor menu, and then load a different chart from the database the newly loaded chart will also render with pixels zoomed in to the custom/user-adjusted size.
  - The current zoom functionality does not impact things like the size of the pixels in an exported PNG image. It only impacts the way the chart is rendered in the Editor.
- Added default pixel size to the globals file for use in GridContext and the Pixel component

## Debug Changes
- Fixed click-and-drag doesn't fill multiple grid pixels on the very first mouse down event. Now, clicking a pixel and entering any other pixel element will fill that pixel based on the fill mode. 
 
  _(Not sure whether I want to turn off drag mode when the cursor leaves the Grid element. -- what if the user left the grid element by mistake? Is it even more convenient to set drag-to-fill true on a single mouse click, instead of requiring the user to hold the mouse down while dragging? TBD.)_
- Fixed fill mode remains active after cursor leaves the Grid component and then re-enters without a new mousedown event. Now, the user must both re-enter the Grid and trigger another click and drag event to re-activate drag-and-fill mode.

## Miscellaneous Changes
- Fix `ChartSymbolsList` import typo (was importing ChartSymbols instead of ChartSymbolsList)
- **Editor Menu**: Remove event target from resetGrid functions, removed ref from download image function, as these are not necessary. Download function now uses id selector instead of React ref.
  - Stub out `SearchBar` component, for adding images to the chart when fill mode is set to **'Symbol'**
- **Carousel**: Refactor Carousel styles so that its centered on the page and header text is aligned with the carousel cards. 
- **Sidebar**: Map over an array of sidebar links, instead of duplicating anchor link code.
- **Grid**: Only render the grid if it already has one or more pixels.

### To-Dos
---
- [ ] Implement additional fill modes: copy/paste a range of pixels, or fill with a symbol from the symbols library